### PR TITLE
Add ability to remove old statuses after an configured amount of days

### DIFF
--- a/app/Config/config.dist.json
+++ b/app/Config/config.dist.json
@@ -1,4 +1,5 @@
 {
+    "cleanUpAfterDays": 30,
     "statusModules": {
         "MarbleRun": {
             "globalConfig": {

--- a/app/Core/Core.js
+++ b/app/Core/Core.js
@@ -16,15 +16,13 @@ var Core = function(httpServer, dashboardSocket) {
     console.log('===================');
     console.log('[Core] Loading all modules...');
 
+    this.config = JSON.parse(FileSystem.readFileSync(__dirname + '/../Config/config.json'));
     this.eventHandler = new Events.EventEmitter();
-
-    this.statusManager = new StatusManager(this.eventHandler);
+    this.statusManager = new StatusManager(this.eventHandler, this.config.cleanUpAfterDays);
 
     new DashboardProvider(httpServer, dashboardSocket, this.eventHandler, this.statusManager);
 
-    this.config = JSON.parse(FileSystem.readFileSync(__dirname + '/../Config/config.json'));
-
-    this.modules = this.loadStatusModules();
+    this.loadStatusModules();
 
     console.log('[Core] Init completed.');
 };

--- a/app/Core/StatusManager.js
+++ b/app/Core/StatusManager.js
@@ -1,16 +1,16 @@
 /**
  * @param {EventEmitter} eventHandler
+ * @param {int} cleanUpAfterDays
  * @constructor
  */
-var StatusManager = function(eventHandler) {
-    /**
-     * {EventEmitter}
-     */
+var StatusManager = function(eventHandler, cleanUpAfterDays) {
+    /** {EventEmitter} */
     this.eventHandler = eventHandler;
 
-    /**
-     * @type {{}}
-     */
+    /** {int} */
+    this.cleanUpAfterDays = cleanUpAfterDays;
+
+    /** @type {{}} */
     this.statuses = {};
 };
 
@@ -20,6 +20,8 @@ var StatusManager = function(eventHandler) {
  * @param {object} status
  */
 StatusManager.prototype.newStatus = function(status) {
+    this.removeOldStatuses();
+
     // Add extra attributes to the status object
     status.key = this.getKey(status);
     status.updateTime = new Date().getTime();
@@ -33,6 +35,23 @@ StatusManager.prototype.newStatus = function(status) {
     this.eventHandler.emit('status', status);
 
     return true;
+};
+
+/**
+ * Clean up all the old statuses
+ */
+StatusManager.prototype.removeOldStatuses = function() {
+    var allowedStatusDate = new Date().getTime() - (1000 * 60 * 60 * 24 * this.cleanUpAfterDays);
+
+    for (var statusKey in this.statuses) {
+        if (this.statuses[statusKey].updateTime < allowedStatusDate) {
+            console.log(
+                '[StatusManager] Removing status ' + this.statuses[statusKey].key
+                + ' because it\'s older then ' + this.cleanUpAfterDays + ' days.'
+            );
+            delete this.statuses[statusKey];
+        }
+    }
 };
 
 /**


### PR DESCRIPTION
### What

Add ability to remove old statuses after an configured amount of days.

There is now a config line where you can enter the amount of days after when a status should be removed. This of course only happens when the status wasn't updated for the configured amount of days.

```json
{
    "cleanUpAfterDays": 30,

    "_comment": "rest of the config..."
}
```