### PR TITLE
Fix marble queue and let the started status pulse in the dashboard

### DIFF
--- a/public/style/dashboard.css
+++ b/public/style/dashboard.css
@@ -57,13 +57,27 @@ body {
 }
 
 .status-started {
-    color: rgb(117, 96, 46);
-    background: rgba(255, 204, 102, .8);
+    animation: pulse-started 2s linear infinite;
 }
 
 .status-failure {
     color: rgb(109, 54, 54);
     background: rgba(236, 122, 96, .8);
+}
+
+@keyframes pulse-started {
+    0% {
+        background: rgba(255, 204, 102, .95);
+        color: rgb(117, 96, 46);
+    }
+    50% {
+        background: rgba(255, 204, 102, .5);
+        color: rgb(86, 66, 43);
+    }
+    100% {
+        background: rgba(255, 204, 102, .95);
+        color: rgb(117, 96, 46);
+    }
 }
 
 .status .project {


### PR DESCRIPTION
### What

This PR fixes double marble run fire commands by postponing the firing if the marble run is already firing. Also the started status in the dashboard is now pulsating.