### PR TITLE
Remove the project name from the hookr calls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,13 @@ cache:
 
 before_install:
     - curl -s -o ~/hookr.sh https://hookr.enrise.com/clients/travis.sh && chmod +x ~/hookr.sh
-    - ~/hookr.sh "CIMonitor" "CIMonitor" "started"
+    - ~/hookr.sh "CIMonitor" "started"
 
 script:
     - sleep 30s;
     
 after_success:
-    - ~/hookr.sh "CIMonitor" "CIMonitor" "success"
-    # - ~/hookr.sh "Webistrano" "CIMonitor"
+    - ~/hookr.sh "CIMonitor" "success"
     
 after_failure:
-    - ~/hookr.sh "CIMonitor" "CIMonitor" "failure"
+    - ~/hookr.sh "CIMonitor" "failure"


### PR DESCRIPTION
### What

Remove the project name from the hookr calls.
This is no longer needed with the updated hookr.