### PR TITLE
Switch to a PI-Blaster setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ limit!
 1. Download CIMonitors source code onto your raspberry pi (or other
    machine)
 1. Run `npm install --production`
+1. Make sure you have [pi-blaster](https://github.com/sarfata/pi-blaster) running on your pi
 1. Copy the config file (`cp app/Config/config.dist.json
     app/Config/config.json`) and make changes accordingly.
 1. To start the server, run `node app/server.js`.

--- a/app/Config/config.dist.json
+++ b/app/Config/config.dist.json
@@ -56,6 +56,13 @@
                     }
                 }
             ]
+        },
+        "LedStrip": {
+            "globalConfig": {
+                "gpioPinRed": 23,
+                "gpioPinGreen": 24,
+                "gpioPinBlue": 18
+            }
         }
     }
 }

--- a/app/StatusModule/LedStrip.js
+++ b/app/StatusModule/LedStrip.js
@@ -1,6 +1,6 @@
 var util = require('util');
 var StatusModule = require('./StatusModule');
-var exec = require('child_process').exec;
+var piblaster = require('pi-blaster.js');
 
 /**
  * LedStrip
@@ -26,10 +26,9 @@ LedStrip.prototype.init = function() {
 };
 
 LedStrip.prototype.setColor = function(red, green, blue) {
-    console.log('[LedStrip] Color red:' + red + ' green:' + green + ' blue:' + blue);
-    exec('pigs p ' + this.redPin + ' ' + red);
-    exec('pigs p ' + this.greenPin + ' ' + green);
-    exec('pigs p ' + this.bluePin + ' ' + blue);
+    piblaster.setPwm(this.redPin, red);
+    piblaster.setPwm(this.greenPin, green);
+    piblaster.setPwm(this.bluePin, blue);
 };
 
 /**
@@ -39,23 +38,23 @@ LedStrip.prototype.setColor = function(red, green, blue) {
  */
 LedStrip.prototype.handleStatus = function(status) {
     if (this.statusManager.hasFailureStatus()) {
-        this.setColor(80, 0, 0);
+        this.setColor(0.31, 0, 0);
         return;
     }
 
     if (this.statusManager.hasStartedStatus()) {
-        this.setColor(80, 20, 0);
+        this.setColor(0.31, 0.08, 0);
         return;
     }
 
-    this.setColor(0, 30, 0);
+    this.setColor(0, 0.12, 0);
 };
 
 /**
  * Prepares the gpio pins. Turns the green light on, turns the orange and red light off.
  */
 LedStrip.prototype.prepareRelay = function() {
-    this.setColor(0, 50, 50);
+    this.setColor(0, 0.19, 0.19);
 };
 
 module.exports = LedStrip;

--- a/app/StatusModule/MarbleRun.js
+++ b/app/StatusModule/MarbleRun.js
@@ -1,6 +1,6 @@
 var util = require('util');
 var StatusModule = require('./StatusModule');
-var exec = require('child_process').exec;
+var piblaster = require('pi-blaster.js');
 
 /**
  * MarbleRun
@@ -32,17 +32,6 @@ MarbleRun.prototype.init = function() {
 
     /** @type {boolean} */
     this.isFiring = false;
-
-    this.prepareRelay();
-};
-
-/**
- * Prepare te relay for on/off toggling
- */
-MarbleRun.prototype.prepareRelay = function() {
-    exec('gpio mode ' + this.pin + ' out');
-    exec('gpio write ' + this.pin + ' 1');
-    console.log('[MarbleRun] Set gpio pin ' + this.pin + ' to output mode and switched off.');
 };
 
 /**
@@ -85,11 +74,11 @@ MarbleRun.prototype.execute = function(doConfig) {
     console.log('[MarbleRun] Firing ' + fireAmount + ' marble(s) (' + MarbleRun.availableMarbles + ' left available).');
 
     // Enable the relay to fire a marble.
-    exec('gpio write ' + MarbleRun.pin + ' 0');
+    piblaster.setPwm(MarbleRun.pin, 0);
 
     // Close the relay if all marbles are fired
     setTimeout(function() {
-        exec('gpio write ' + MarbleRun.pin + ' 1');
+        piblaster.setPwm(MarbleRun.pin, 1);
         MarbleRun.isFiring = false;
     }, fireAmount * MarbleRun.oneMarbleFireTime);
 

--- a/app/StatusModule/PowerUp.js
+++ b/app/StatusModule/PowerUp.js
@@ -1,6 +1,6 @@
 var util = require('util');
 var StatusModule = require('./StatusModule');
-var exec = require('child_process').exec;
+var piblaster = require('pi-blaster.js');
 
 /**
  * PowerUp
@@ -28,8 +28,6 @@ PowerUp.prototype.init = function() {
             continue;
         }
 
-        exec('gpio mode ' + pin + ' out');
-        exec('gpio write ' + pin + ' 1');
         console.log('[PowerUp] Set gpio pin ' + pin + ' to output mode and switched off.');
         enabledPins.push(pin);
     }
@@ -42,13 +40,13 @@ PowerUp.prototype.init = function() {
  */
 PowerUp.prototype.execute = function(doConfig) {
     // Switch the relay on for the configured gpio pin
-    exec('gpio write ' + doConfig.gpioPin + ' 1');
+    piblaster.setPwm(doConfig.gpioPin, 0);
     console.log(
         '[PowerUp] Power on gpio pin ' + doConfig.gpioPin + ' for ' + doConfig.powerForMiliSeconds + 'ms.'
     );
 
     setTimeout(function() {
-        exec('gpio write ' + doConfig.gpioPin + ' 0');
+        piblaster.setPwm(doConfig.gpioPin, 1);
         console.log('[PowerUp] Power off gpio pin ' + doConfig.gpioPin + '.');
     }, doConfig.powerForMiliSeconds);
 };

--- a/app/StatusModule/TrafficLight.js
+++ b/app/StatusModule/TrafficLight.js
@@ -1,6 +1,5 @@
 var util = require('util');
 var StatusModule = require('./StatusModule');
-var exec = require('child_process').exec;
 
 var ON = 0;
 var OFF = 1;
@@ -48,9 +47,9 @@ TrafficLight.prototype.handleStatus = function(status) {
         redLight = ON;
     }
 
-    exec('gpio write ' + this.greenPin + ' ' + greenLight);
-    exec('gpio write ' + this.orangePin + ' ' + orangeLight);
-    exec('gpio write ' + this.redPin + ' ' + redLight);
+    piblaster.setPwm(this.greenPin, greenLight);
+    piblaster.setPwm(this.orangePin, orangeLight);
+    piblaster.setPwm(this.redPin, redLight);
     console.log(
         '[TrafficLight] Green is ' + (greenLight === ON) ? 'on' : 'off' + ', orange is '
         + (orangeLight === ON) ? 'on' : 'off' + ', and red is ' + (redLight === ON) ? 'on' : 'off' + '.'
@@ -61,12 +60,6 @@ TrafficLight.prototype.handleStatus = function(status) {
  * Prepares the gpio pins. Turns the green light on, turns the orange and red light off.
  */
 TrafficLight.prototype.prepareRelay = function() {
-    exec('gpio mode ' + this.redPin + ' out');
-    exec('gpio write ' + this.redPin + ' ' + OFF);
-    exec('gpio mode ' + this.orangePin + ' out');
-    exec('gpio write ' + this.orangePin + ' ' + OFF);
-    exec('gpio mode ' + this.greenPin + ' out');
-    exec('gpio write ' + this.greenPin + ' ' + ON);
     console.log(
         '[TrafficLight] Set gpio pin ' + this.redPin + ', ' + this.orangePin + ' and ' + this.greenPin
         + ' to output mode and switched off. Green light is on.'

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "body-parser": "~1.15.0",
     "express": "~4.13.4",
+    "pi-blaster.js": "^0.1.1",
     "socket.io": "~1.4.5",
     "validate.js": "^0.9.0"
   },


### PR DESCRIPTION
### What

To support the led-strip module, we enabled PI-Blaster on the raspberry PI. This causes the implementation to differ. Using PI-Blaster on the raspberry PI is now required.