### PR TITLE
Allow a CIMonitor to listen to the statuses of a public CIMonitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-![CI Monitor](https://cloud.githubusercontent.com/assets/6495166/14582332/071b3286-0402-11e6-9104-144f5e150189.png)
+![CIMonitor](https://cloud.githubusercontent.com/assets/6495166/14582332/071b3286-0402-11e6-9104-144f5e150189.png)
 ===
 
-The CI Monitor is a place where all your project statuses come together.
+The CIMonitor is a place where all your project statuses come together.
 Check if all tests have passed, and if deployments are successful. All
 in one overview.
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ configuration for that module in the global config file
 }
 ```
 
+### Listen to another CIMonitor
+
+In case you want to have a second raspberry pi running, but listen to the same statuses, you can provide a web hook
+URL to the other running CIMonitor. That way all the statuses that are pushed to the dashboard, are pushed to the
+second CIMonitor instance as well. To make this work, add a listen URL in your config:
+
+```json
+{
+    "listenUrl": "http://ci.example.org"
+}
+```
+
+The same URL should be used as the status dashboard.
+
 # Modules
 
 Currently modules are pre-installed in the repository, later this will be npm modules so can be added with ease.

--- a/app/Config/config.dist.json
+++ b/app/Config/config.dist.json
@@ -1,5 +1,7 @@
 {
+    "_comment": "Remove everything you do not need!",
     "cleanUpAfterDays": 30,
+    "listenUrl": "http://ci.example.org",
     "statusModules": {
         "MarbleRun": {
             "globalConfig": {
@@ -61,7 +63,33 @@
             "globalConfig": {
                 "gpioPinRed": 23,
                 "gpioPinGreen": 24,
-                "gpioPinBlue": 18
+                "gpioPinBlue": 18,
+                "colors": {
+                    "failure": {
+                        "r": 255,
+                        "g": 0,
+                        "b": 0,
+                        "intensity": 100
+                    },
+                    "success": {
+                        "r": 0,
+                        "g": 255,
+                        "b": 0,
+                        "intensity": 100
+                    },
+                    "started": {
+                        "r": 255,
+                        "g": 50,
+                        "b": 0 ,
+                        "intensity": 100
+                    },
+                    "neutral": {
+                        "r": 0,
+                        "g": 255,
+                        "b": 0,
+                        "intensity": 30
+                    }
+                }
             }
         },
         "HueLight": {

--- a/app/Core/CIMonitorListener.js
+++ b/app/Core/CIMonitorListener.js
@@ -16,18 +16,28 @@ var CIMonitorListener = function(webHookUrl, statusManager) {
     this.statusManager = statusManager;
 
     this.listenToStatuses();
-
-    console.log('[CIMonitorListener] Waiting for statuses.');
 };
 
 CIMonitorListener.prototype.listenToStatuses = function() {
     var CIMonitorListener = this;
 
-    var socket = io.connect(this.webHookUrl);
-    socket.on('status', function(data) {
-        console.log('[CIMonitorListener] RECEIVED STATUS!!!');
-        CIMonitorListener.statusManager.newStatus(data);
-    });
+    var socket = require('socket.io-client')(this.webHookUrl);
+    socket.on('connect', function() { CIMonitorListener.onConnect(); });
+    socket.on('status', function(status) { CIMonitorListener.onStatus(status); });
+    socket.on('disconnect', function() { CIMonitorListener.onDisconnect(); });
+};
+
+CIMonitorListener.prototype.onConnect = function() {
+    console.log('[CIMonitorListener] Connected to the external CIMonitor at ' + this.webHookUrl + '.');
+};
+
+CIMonitorListener.prototype.onStatus = function(data) {
+    console.log('[CIMonitorListener] New external status comming in...');
+    this.statusManager.newStatus(data);
+};
+
+CIMonitorListener.prototype.onDisconnect = function() {
+    console.log('[CIMonitorListener] Disconnected from ' + this.webHookUrl + '.');
 };
 
 module.exports = CIMonitorListener;

--- a/app/Core/CIMonitorListener.js
+++ b/app/Core/CIMonitorListener.js
@@ -1,0 +1,33 @@
+var io = require('socket.io-client');
+
+/**
+ * CIMonitorListener
+ *
+ * @param {string} webHookUrl
+ * @param {StatusManager} statusManager
+ * @constructor
+ */
+var CIMonitorListener = function(webHookUrl, statusManager) {
+    console.log('[CIMonitorListener] Hooking into web socket ' + webHookUrl + ' to listen to statuses...');
+
+    this.webHookUrl = webHookUrl;
+
+    /** {StatusManager} */
+    this.statusManager = statusManager;
+
+    this.listenToStatuses();
+
+    console.log('[CIMonitorListener] Waiting for statuses.');
+};
+
+CIMonitorListener.prototype.listenToStatuses = function() {
+    var CIMonitorListener = this;
+
+    var socket = io.connect(this.webHookUrl);
+    socket.on('status', function(data) {
+        console.log('[CIMonitorListener] RECEIVED STATUS!!!');
+        CIMonitorListener.statusManager.newStatus(data);
+    });
+};
+
+module.exports = CIMonitorListener;

--- a/app/Core/Core.js
+++ b/app/Core/Core.js
@@ -1,5 +1,6 @@
 var StatusManager = require('./StatusManager');
 var DashboardProvider = require('./DashboardProvider');
+var CIMonitorListener = require('./CIMonitorListener');
 var GitLabAdapter = require('../Adapter/GitLab');
 var Events = require('events');
 var FileSystem = require('fs');
@@ -21,6 +22,10 @@ var Core = function(httpServer, dashboardSocket) {
     this.eventHandler = new Events.EventEmitter();
     this.statusManager = new StatusManager(this.eventHandler, this.config.cleanUpAfterDays);
     this.gitlabAdapter = new GitLabAdapter(this.statusManager);
+
+    if (typeof this.config.listenUrl !== 'undefined') {
+        new CIMonitorListener(this.config.listenUrl, this.statusManager);
+    }
 
     new DashboardProvider(httpServer, dashboardSocket, this.eventHandler, this.statusManager);
 

--- a/app/Core/DashboardProvider.js
+++ b/app/Core/DashboardProvider.js
@@ -52,7 +52,7 @@ DashboardProvider.prototype.openDashboardSocket = function() {
         var socketId = DashboardProvider.socketId++;
 
         DashboardProvider.dashboardSockets[socketId] = connectedSocked;
-        connectedSocked.emit('status', DashboardProvider.getDashboardStatuses());
+        connectedSocked.emit('statuses', DashboardProvider.getDashboardStatuses());
         console.log(
             '[DashboardProvider] Dashboard connected with id ' + socketId + ' and has now the latest statuses.'
         );
@@ -86,7 +86,8 @@ DashboardProvider.prototype.pushStatusToDashboards = function(status) {
     var dashboardStatuses = this.getDashboardStatuses();
 
     for (var id in this.dashboardSockets) {
-        this.dashboardSockets[id].emit('status', dashboardStatuses);
+        this.dashboardSockets[id].emit('statuses', dashboardStatuses);
+        this.dashboardSockets[id].emit('status', status);
         console.log('[DashboardProvider] Sent update to dashboard with id ' + id + '.');
     }
 };

--- a/app/Core/DashboardProvider.js
+++ b/app/Core/DashboardProvider.js
@@ -46,7 +46,7 @@ DashboardProvider.prototype.attachStatusListener = function() {
 DashboardProvider.prototype.openDashboardSocket = function() {
     var DashboardProvider = this;
 
-    var socket  = this.dashboardSocket.listen(this.httpServer);
+    var socket = this.dashboardSocket.listen(this.httpServer);
     socket.on('connection', function(socket) {
         var connectedSocked = socket;
         var socketId = DashboardProvider.socketId++;

--- a/app/StatusModule/LedStrip.js
+++ b/app/StatusModule/LedStrip.js
@@ -10,8 +10,6 @@ var piblaster = require('pi-blaster.js');
  * @constructor
  */
 var LedStrip = function(config, statusManager) {
-    StatusModule.call(this, config, statusManager);
-
     this.colors = {
         failure: {
             r: 255,
@@ -49,6 +47,8 @@ var LedStrip = function(config, statusManager) {
     this.currentColor = 'off';
 
     this.currentIntencity = 100;
+
+    StatusModule.call(this, config, statusManager);
 };
 util.inherits(LedStrip, StatusModule);
 
@@ -63,7 +63,6 @@ LedStrip.prototype.init = function() {
     if (typeof this.config.colors !== 'undefined') {
         for (var overWriteColor in this.config.colors) {
             if (this.config.colors.hasOwnProperty(overWriteColor)) {
-                console.log('overwriting ' + overWriteColor + ': ' + JSON.stringify(this.config.colors[overWriteColor]));
                 this.colors[overWriteColor] = this.config.colors[overWriteColor];
             }
         }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "start": "node app/server.js"
   },
   "keywords": [
     "depoloyment",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "express": "~4.13.4",
     "pi-blaster.js": "^0.1.1",
     "socket.io": "~1.4.5",
+    "socket.io-client": "^1.7.2",
     "validate.js": "^0.9.0"
   },
   "devDependencies": {

--- a/public/images/types/deploy.svg
+++ b/public/images/types/deploy.svg
@@ -35,7 +35,12 @@
 </g>
 <g id="Glass_8_">
 	<g>
-		<circle style="fill:#CCCCCC;" cx="48" cy="16.013" r="8"/>
+		<circle style="fill:#4D4D4D;" cx="48" cy="16.013" r="8"/>
+	</g>
+</g>
+<g id="Glass_9_">
+	<g>
+		<circle style="fill:#E6E6E6;" cx="48" cy="16.013" r="4"/>
 	</g>
 </g>
 </svg>

--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,7 @@
         }
         setTimeout(function() { updateTimesEveryMinute() }, 10000);
 
-        socket.on('status', function(update) {
+        socket.on('statuses', function(update) {
             console.log(update);
 
             $('.no-connection').addClass('hidden');


### PR DESCRIPTION
### What

This PR adds the ability for one CIMonitor instance to listen to another running CIMonitor instance. This is interesting when you want to have a second raspberry pi execute StatusModules but using the same statuses.