### PR TITLE
Upped the resolution of avatars loaded from gravatar.com to prevent blurriness

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -42,9 +42,9 @@ Vue.component('status-block', {
             return '/images/types/' + this.status.type + '.svg';
         },
         getStatusPhoto: function() {
-            statusPhoto = this.status.photo;
+            var statusPhoto = this.status.photo;
             // Photos from Gravatar will get blurry if we do not bump up the resolution.
-            if (statusPhoto.indexOf('gravatar.com') != -1) {
+            if (statusPhoto.indexOf('gravatar.com') !== -1) {
                 statusPhoto = statusPhoto.replace('s=80', 's=300');
             }
             return 'background-image: url(\'' + statusPhoto + '\')'

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -42,7 +42,12 @@ Vue.component('status-block', {
             return '/images/types/' + this.status.type + '.svg';
         },
         getStatusPhoto: function() {
-            return 'background-image: url(\'' + this.status.photo + '\')'
+            statusPhoto = this.status.photo;
+            // Photos from Gravatar will get blurry if we do not bump up the resolution.
+            if (statusPhoto.indexOf('gravatar.com') != -1) {
+                statusPhoto = statusPhoto.replace('s=80', 's=300');
+            }
+            return 'background-image: url(\'' + statusPhoto + '\')'
         },
         getTimeAgo: function() {
             var timeAgo = moment(this.status.updateTime).from(this.now);


### PR DESCRIPTION
### What has been done
A check has been added to see if a avatar is loaded from gravatar.com, and if so, it will up the size from 80px to 300px, which is exactly what you would need on a double density display like Apple Retina.

### How to test
- Pull this PR
- See clear Gravatar images
