### PR TITLE
Add allowed failure status in the dashboard for GitLab statuses

### DIFF
--- a/app/Adapter/GitLab.js
+++ b/app/Adapter/GitLab.js
@@ -25,20 +25,16 @@ GitLab.prototype.processEvent = function(data) {
     }
 };
 
-GitLab.prototype.translateStatus = function(status) {
-    var ciMonitorStatus = 'success';
-
-    switch(status) {
-        case 'pending':
-        case 'running':
-            ciMonitorStatus = 'started';
-            break;
-        case 'failed':
-            ciMonitorStatus = 'failure';
-            break;
+GitLab.prototype.translateStatus = function(status, allowFailure) {
+    if (status === 'pending' || status === 'running') {
+        return 'started';
     }
 
-    return ciMonitorStatus;
+    if (status === 'failed') {
+        return allowFailure ? 'allowed-failure' : 'failure';
+    }
+
+    return 'success';
 };
 
 GitLab.prototype.handleBuild = function(data) {
@@ -50,7 +46,7 @@ GitLab.prototype.handleBuild = function(data) {
     var job = {
         name: data.build_name,
         stage: data.build_stage,
-        status: this.translateStatus(data.build_status),
+        status: this.translateStatus(data.build_status, data.build_allow_failure),
     };
 
     var pipeline = {

--- a/app/Core/StatusManager.js
+++ b/app/Core/StatusManager.js
@@ -143,6 +143,7 @@ StatusManager.prototype.filterType = function(stage) {
 StatusManager.prototype.determineStageStatus = function(stage, jobs) {
     var hasStarted = false;
     var hasFailure = false;
+    var hasAllowedFailure = false;
 
     for (var jobKey in jobs) {
         if (jobs[jobKey].stage === stage) {
@@ -152,6 +153,9 @@ StatusManager.prototype.determineStageStatus = function(stage, jobs) {
             if (jobs[jobKey].status === 'failure') {
                 hasFailure = true;
             }
+            if (jobs[jobKey].status === 'allowed-failure') {
+                hasAllowedFailure = true;
+            }
         }
     }
 
@@ -160,6 +164,9 @@ StatusManager.prototype.determineStageStatus = function(stage, jobs) {
     }
     if (hasStarted) {
         return 'started';
+    }
+    if (hasAllowedFailure) {
+        return 'allowed-failure';
     }
     return 'success';
 };

--- a/public/style/dashboard.css
+++ b/public/style/dashboard.css
@@ -167,7 +167,7 @@ body {
     position: relative;
 
     /* box-model */
-    padding-right: 20px;
+    padding-right: 28px;
 
     /* visual */
     background: rgb(135, 192, 86);
@@ -176,7 +176,7 @@ body {
     /* positioning */
     position: absolute;
     top: 5px;
-    right: 8px;
+    right: 12px;
     transform: skew(19deg);
 
     /* box-model */

--- a/public/style/dashboard.css
+++ b/public/style/dashboard.css
@@ -233,10 +233,6 @@ body {
     /* visual */
     background: rgb(236, 122, 96);
 }
-.status.allowed-failure .status-info {
-    /* visual */
-    background: rgb(19, 162, 209);
-}
 
 .status-time {
     /* positioning */

--- a/public/style/dashboard.css
+++ b/public/style/dashboard.css
@@ -158,6 +158,42 @@ body {
     /* visual */
     background: rgb(236, 122, 96);
 }
+.job-container .allowed-failure {
+    /* visual */
+    background: rgb(236, 122, 96);
+}
+.status-stages .allowed-failure {
+    /* positioning */
+    position: relative;
+
+    /* box-model */
+    padding-right: 20px;
+
+    /* visual */
+    background: rgb(135, 192, 86);
+}
+.status-stages .allowed-failure:after {
+    /* positioning */
+    position: absolute;
+    top: 5px;
+    right: 8px;
+    transform: skew(19deg);
+
+    /* box-model */
+    width: 22px;
+    height: 22px;
+    text-align: center;
+
+    /* typography */
+    font-weight: bold;
+
+    /* visual */
+    background: rgb(255, 204, 102);
+    border-radius: 50%;
+
+    /* misc */
+    content: '!';
+}
 .job-container .todo {
     /* visual */
     background: rgba(255, 204, 102, 0.4);
@@ -196,6 +232,10 @@ body {
 .status.failure .status-info {
     /* visual */
     background: rgb(236, 122, 96);
+}
+.status.allowed-failure .status-info {
+    /* visual */
+    background: rgb(19, 162, 209);
 }
 
 .status-time {

--- a/public/style/dashboard.css
+++ b/public/style/dashboard.css
@@ -177,7 +177,6 @@ body {
     position: absolute;
     top: 0;
     right: 0;
-    /*transform: skew(19deg);*/
 
     /* box-model */
     width: 34px;

--- a/public/style/dashboard.css
+++ b/public/style/dashboard.css
@@ -175,21 +175,21 @@ body {
 .status-stages .allowed-failure:after {
     /* positioning */
     position: absolute;
-    top: 5px;
-    right: 12px;
-    transform: skew(19deg);
+    top: 0;
+    right: 0;
+    /*transform: skew(19deg);*/
 
     /* box-model */
-    width: 22px;
-    height: 22px;
+    width: 34px;
+    height: 28px;
     text-align: center;
+    padding-top: 6px;
 
     /* typography */
     font-weight: bold;
 
     /* visual */
     background: rgb(255, 204, 102);
-    border-radius: 50%;
 
     /* misc */
     content: '!';


### PR DESCRIPTION
### What

@renatomefi requested that the "allowed-failure" status gets added, because it's possible that jobs fail, but have the `"build_allow_failure" = true`. The CIMonitor now takes this into account when displaying jobs/stages with errors.

* The job will remain failed (because it simply did fail)
* The stage will be green (if no other jobs failed), but it will display a warning exclamation mark.

### Screenshot

![image](https://user-images.githubusercontent.com/6495166/33499461-4371e6d8-d6d5-11e7-839c-3a43b60df2f8.png)

