### PR TITLE
Re-add mkdocs file

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: CIMonitor
+theme: readthedocs
+pages:
+    - Home: index.md
+    - Setup CIMonitor: setup.md
+    - Setup Raspberry: setup-raspberry.md
+    - Connecting CI: connecting-ci.md
+    - Statuses: statuses.md
+    - StatusModules: status-modules.md
+    - Linking CIMonitors: linking-cimonitors.md


### PR DESCRIPTION
### What

With the migration to version 2, the mkdocs file got lost, thus readthedocs is not updating anymore. Adding this file should trigger new builds agian.