### PR TITLE
Allow no userImage, order statuses from store, fix time padding

### DIFF
--- a/client/components/Dashboard/dashboard.vue
+++ b/client/components/Dashboard/dashboard.vue
@@ -15,7 +15,7 @@ import Status from '../Status';
 import VideoOverlay from '../VideoOverlay';
 import SettingsPanel from '../SettingsPanel';
 import { STATUS_CONNECTION_LOST, STATUS_NO_STATUSES } from '../Status/staticStatuses';
-import { STATUS_GET_GLOBAL_STATE } from '../../store/StaticGetters';
+import { STATUS_GET_GLOBAL_STATE, STATUS_GET_STATUSES_ORDERED } from '../../store/StaticGetters';
 
 export default {
     components: { ToolBar, Status, VideoOverlay, SettingsPanel },
@@ -48,7 +48,7 @@ export default {
             return this.$store.getters[STATUS_GET_GLOBAL_STATE];
         },
         statuses() {
-            return this.$store.state.statuses.statuses;
+            return this.$store.getters[STATUS_GET_STATUSES_ORDERED];
         },
     },
 };

--- a/client/components/SettingsPanel/panels/Statuses/statuses.vue
+++ b/client/components/SettingsPanel/panels/Statuses/statuses.vue
@@ -24,6 +24,8 @@
 </template>
 
 <script>
+import { STATUS_GET_STATUSES_ORDERED } from '../../../../store/StaticGetters';
+
 export default {
     data() {
         return {};
@@ -42,7 +44,7 @@ export default {
     },
     computed: {
         statuses() {
-            return this.$store.state.statuses.statuses;
+            return this.$store.getters[STATUS_GET_STATUSES_ORDERED];
         },
     },
 };

--- a/client/components/Status/status.vue
+++ b/client/components/Status/status.vue
@@ -8,8 +8,8 @@
                     <i :class="stateToIcon(job.state)" /> {{ job.name }}
                 </div>
             </div>
-            <div class="sub-title">
-                <span v-if="status.subTitle">{{ status.subTitle }}</span>
+            <div class="info">
+                <span class="sub-title" v-if="status.subTitle">{{ status.subTitle }}</span>
                 <span class="time-ago" v-if="now"> <i class="far fa-clock" /> {{ timeAgo }} </span>
             </div>
         </div>
@@ -95,6 +95,7 @@ $border-bottom: 3px
 
 .sub-title
     font-size: 30px
+    padding-right: 10px
 
 .user-image,
 .image
@@ -110,7 +111,6 @@ $border-bottom: 3px
     margin-right: 20px
 
 .time-ago
-    padding-left: 10px
     font-size: 20px
 
 .jobs

--- a/client/components/ToolBar/tool-bar.vue
+++ b/client/components/ToolBar/tool-bar.vue
@@ -4,7 +4,7 @@
         <div class="toolbar">
             <button @click="openGitHub();"><i class="fab fa-github" /></button>
             <div class="logo"><img :src="trafficLightImage" alt="logo" /></div>
-            <button @click="openSettings();" title="Clear dashboard"><i class="fas fa-cog" /></button>
+            <button @click="openSettings();"><i class="fas fa-cog" /></button>
         </div>
     </div>
 </template>

--- a/client/store/StaticGetters.js
+++ b/client/store/StaticGetters.js
@@ -1,1 +1,2 @@
 export const STATUS_GET_GLOBAL_STATE = 'statusGetGlobalState';
+export const STATUS_GET_STATUSES_ORDERED = 'statusGetStatusesOrdered';

--- a/client/store/modules/StatusStore.js
+++ b/client/store/modules/StatusStore.js
@@ -18,6 +18,7 @@ const getters = {
 
         return 'success';
     },
+
     [STATUS_GET_STATUSES_ORDERED]: state => {
         return state.statuses.sort((statusA, statusB) => {
             const timeA = moment(statusA.time);

--- a/client/store/modules/StatusStore.js
+++ b/client/store/modules/StatusStore.js
@@ -1,5 +1,6 @@
-import { STATUS_GET_GLOBAL_STATE } from '../StaticGetters';
+import { STATUS_GET_GLOBAL_STATE, STATUS_GET_STATUSES_ORDERED } from '../StaticGetters';
 import { STATUS_SET_STATUSES } from '../StaticMutations';
+import moment from 'moment';
 
 const state = {
     statuses: [],
@@ -16,6 +17,14 @@ const getters = {
         }
 
         return 'success';
+    },
+    [STATUS_GET_STATUSES_ORDERED]: state => {
+        return state.statuses.sort((statusA, statusB) => {
+            const timeA = moment(statusA.time);
+            const timeB = moment(statusB.time);
+
+            return timeA.isBefore(timeB) ? 1 : -1;
+        });
     },
 };
 

--- a/cypress/fixtures/status/custom-status-5.json
+++ b/cypress/fixtures/status/custom-status-5.json
@@ -1,0 +1,5 @@
+{
+    "key": "ci-monitor-status-5",
+    "title": "CIMonitor/Minimal",
+    "state": "success"
+}

--- a/cypress/integration/dashboard-custom-status.spec.js
+++ b/cypress/integration/dashboard-custom-status.spec.js
@@ -16,5 +16,7 @@ context('Custom states', () => {
         cy.pushStatus('custom-status-2-success.json');
         cy.wait(1000);
         cy.pushStatus('custom-status-4-started.json');
+        cy.wait(1000);
+        cy.pushStatus('custom-status-5.json');
     });
 });

--- a/server/domain/status/Status.js
+++ b/server/domain/status/Status.js
@@ -19,9 +19,9 @@ class Status {
 
     isOld() {
         const oneWeekAgo = Moment().subtract(1, 'weeks');
-        const statusCreatedTime = Moment(this.data.time);
+        const statusTime = Moment(this.data.time);
 
-        return statusCreatedTime.isBefore(oneWeekAgo);
+        return statusTime.isBefore(oneWeekAgo);
     }
 }
 

--- a/server/domain/status/StatusFactory.js
+++ b/server/domain/status/StatusFactory.js
@@ -164,6 +164,10 @@ class StatusFactory {
     }
 
     static filterUserImage(data) {
+        if (!data.userImage) {
+            return data;
+        }
+
         if (data.userImage.indexOf('gravatar.com') === -1) {
             return data;
         }


### PR DESCRIPTION
### What

Tackled a couple of bugs:

- Statuses were not correctly ordered when returned from the store
- It was not possible to not submit a `Status` without `userImage`, this is now possible again
- Some small padding issue when not providing a subTitle, the time would have an weird offset