### PR TITLE
Show the project avatar if it a valid image is available

### DIFF
--- a/client/components/Status/status.vue
+++ b/client/components/Status/status.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="status" :class="status.state">
-        <img v-if="status.image" :src="status.image" class="image" />
+        <img v-if="status.image && this.showImage" :src="status.image" class="image" @error="hideImage();" />
         <div class="details">
             <div class="title">{{ status.title }}</div>
             <jobs-and-stages :jobs="status.jobs" :stages="status.stages" />
@@ -28,8 +28,17 @@ export default {
             default: null,
         },
     },
+    data: function() {
+        return {
+            showImage: true,
+        };
+    },
     components: { JobsAndStages },
-    methods: {},
+    methods: {
+        hideImage() {
+            this.showImage = false;
+        },
+    },
     computed: {
         timeAgo() {
             if (!this.now) {

--- a/client/components/Status/status.vue
+++ b/client/components/Status/status.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="status" :class="status.state">
-        <img v-if="status.image && this.showImage" :src="status.image" class="image" @error="hideImage();" />
+        <img v-if="status.image && this.showImage" :src="status.image" class="image" @error="hideImage" />
         <div class="details">
             <div class="title">{{ status.title }}</div>
             <jobs-and-stages :jobs="status.jobs" :stages="status.stages" />

--- a/server/domain/status/adapter/GitLab.js
+++ b/server/domain/status/adapter/GitLab.js
@@ -22,7 +22,7 @@ class StatusAdapterGitLab {
             state: this.pipelineStatusToState(data.object_attributes.status),
             title: data.project.path_with_namespace,
             subTitle: data.object_attributes.ref,
-            // image: data.project.avatar_url, leaving out for now as the image is not shown when not logged in
+            image: data.project.avatar_url,
             userImage: data.user.avatar_url,
             stages: data.object_attributes.stages,
             jobs: data.builds.map(build => {


### PR DESCRIPTION
### What
Some adapters have a project image available, e.g. GitLab.
If this image is set and can be loaded, it will now be displayed on the monitor.