### PR TITLE
Hide scroll-bars in webkit browsers

### DIFF
--- a/client/sass/dashboard.sass
+++ b/client/sass/dashboard.sass
@@ -11,5 +11,8 @@ body
     font-family: $font
     line-height: 1.2
 
+*::-webkit-scrollbar
+    display: none
+
 a
     color: $color-info


### PR DESCRIPTION
### What

Scrolling is not really something that's meant to be done for a stand-alone monitoring display. This PR hides the scrollbar in webkit browsers (so at least chrome and chromium), but doesn't disable scrolling. So if you look up a polluted dashboard, you can still scroll down.