### PR TITLE
Change warning color to be more orange

### DIFF
--- a/server/domain/module/LedStrip.js
+++ b/server/domain/module/LedStrip.js
@@ -23,7 +23,7 @@ class LedStrip extends AbstractModule {
             },
             warning: {
                 r: 255,
-                g: 50,
+                g: 130,
                 b: 0,
                 intensity: 100,
             },


### PR DESCRIPTION
### What
The warning color displayed on the LEDstrip was to much on the red side. It is changed to a more orange color.