### PR TITLE
Implement desktop notifications in the settings panel

### DIFF
--- a/client/client.js
+++ b/client/client.js
@@ -37,7 +37,7 @@ new Vue({
 
             try {
                 new Notification(`CIMonitor • ${status.state}`, {
-                    body: `${status.title} • ${status.subTitle}: ${status.state}`,
+                    body: `${status.title}${status.subTitle ? ` • ${status.subTitle}` : ''}: ${status.state}`,
                     icon: CIMonitorLogo,
                 });
             } catch (error) {

--- a/client/client.js
+++ b/client/client.js
@@ -30,6 +30,18 @@ new Vue({
                 .querySelector('link[rel="shortcut icon"]')
                 .setAttribute('href', `/images/favicon/${globalState}.png`);
         },
+        pushNotification(status) {
+            try {
+                if (this.$store.state.settings.pushNotifications) {
+                    new Notification(`CIMonitor • ${status.state}`, {
+                        body: `${status.title} • ${status.subTitle}: ${status.state}`,
+                        icon: CIMonitorLogo,
+                    });
+                }
+            } catch (error) {
+                // do nothing.
+            }
+        },
     },
     sockets: {
         connect() {
@@ -49,14 +61,7 @@ new Vue({
             this.updateFavicon(this.$store.getters[STATUS_GET_GLOBAL_STATE]);
         },
         [socketEvents.eventTriggerStatus](status) {
-            try {
-                new Notification(`CIMonitor • ${status.state}`, {
-                    body: `${status.title} • ${status.subTitle}: ${status.state}`,
-                    icon: CIMonitorLogo,
-                });
-            } catch (error) {
-                // do nothing.
-            }
+            this.pushNotification(status);
         },
     },
 });

--- a/client/client.js
+++ b/client/client.js
@@ -9,6 +9,7 @@ import socketEvents from '../shared/socketEvents';
 import { STATUS_SET_STATUSES } from './store/StaticMutations';
 import { STATUS_GET_GLOBAL_STATE } from './store/StaticGetters';
 import VersionChecker from './classes/VersionChecker';
+import CIMonitorLogo from './components/EmptyBoard/logo.png';
 
 Vue.use(VueSocketIo, io());
 Vue.use(Vuex);
@@ -46,6 +47,16 @@ new Vue({
             this.$store.commit(STATUS_SET_STATUSES, statuses);
 
             this.updateFavicon(this.$store.getters[STATUS_GET_GLOBAL_STATE]);
+        },
+        [socketEvents.eventTriggerStatus](status) {
+            try {
+                new Notification(`CIMonitor • ${status.state}`, {
+                    body: `${status.title} • ${status.subTitle}: ${status.state}`,
+                    icon: CIMonitorLogo,
+                });
+            } catch (error) {
+                // do nothing.
+            }
         },
     },
 });

--- a/client/client.js
+++ b/client/client.js
@@ -31,13 +31,15 @@ new Vue({
                 .setAttribute('href', `/images/favicon/${globalState}.png`);
         },
         pushNotification(status) {
+            if (!this.$store.state.settings.pushNotifications) {
+                return;
+            }
+
             try {
-                if (this.$store.state.settings.pushNotifications) {
-                    new Notification(`CIMonitor • ${status.state}`, {
-                        body: `${status.title} • ${status.subTitle}: ${status.state}`,
-                        icon: CIMonitorLogo,
-                    });
-                }
+                new Notification(`CIMonitor • ${status.state}`, {
+                    body: `${status.title} • ${status.subTitle}: ${status.state}`,
+                    icon: CIMonitorLogo,
+                });
             } catch (error) {
                 // do nothing.
             }

--- a/client/components/SettingsPanel/panels/Notify/notify.vue
+++ b/client/components/SettingsPanel/panels/Notify/notify.vue
@@ -9,7 +9,7 @@
             browser settings. You can dissable the dashboard notifications any time you like below.
         </p>
         <button class="option" @click="dissableNotifications" :class="{ current: !pushNotifications }">
-            No desktop notifications
+            Dissable desktop notifications
         </button>
         <button class="option" @click="enableNotifications" :class="{ current: pushNotifications }">
             Enable desktop notifications

--- a/client/components/SettingsPanel/panels/Notify/notify.vue
+++ b/client/components/SettingsPanel/panels/Notify/notify.vue
@@ -1,15 +1,53 @@
 <template>
-    <div>Client notifications coming soon...</div>
+    <div>
+        <p>
+            By enabling desktop notifications, you'll receive a push message for every new status pushed to the
+            dashboard.
+        </p>
+        <p>
+            <strong>Note:</strong> If you deny the push notification pup-up, you'll have to re-enable them in your
+            browser settings. You can dissable the dashboard notifications any time you like below.
+        </p>
+        <button class="option" @click="dissableNotifications" :class="{ current: !pushNotifications }">
+            No desktop notifications
+        </button>
+        <button class="option" @click="enableNotifications" :class="{ current: pushNotifications }">
+            Enable desktop notifications
+        </button>
+    </div>
 </template>
 
 <script>
+import CIMonitorLogo from '../../../EmptyBoard/logo.png';
+import { SETTINGS_SET_NOTIFICATIONS_ON, SETTINGS_SET_NOTIFICATIONS_OFF } from '../../../../store/StaticMutations';
+
 export default {
-    data() {
-        return {};
+    methods: {
+        enableNotifications() {
+            Notification.requestPermission().then(() => {
+                new Notification(`CIMonitor`, {
+                    body: `Notifications are enabled!`,
+                    icon: CIMonitorLogo,
+                });
+            });
+            this.$store.commit(SETTINGS_SET_NOTIFICATIONS_ON);
+        },
+        dissableNotifications() {
+            this.$store.commit(SETTINGS_SET_NOTIFICATIONS_OFF);
+        },
     },
-    methods: {},
-    computed: {},
+    computed: {
+        pushNotifications() {
+            return this.$store.state.settings.pushNotifications;
+        },
+    },
 };
 </script>
 
-<style lang="sass" rel="stylesheet/sass" scoped></style>
+<style lang="sass" rel="stylesheet/sass" scoped>
+.option
+    @extend %radio-option
+
+hr
+    @extend %line-break
+</style>

--- a/client/components/SettingsPanel/panels/Personalize/personalize.vue
+++ b/client/components/SettingsPanel/panels/Personalize/personalize.vue
@@ -1,14 +1,17 @@
 <template>
     <div>
-        <p><strong>Font size:</strong></p>
-        <p>@todo</p>
+        <p><strong>Status size:</strong></p>
+        <p>
+            To increase the size of the dashboard, please use the built in zoom functionality using `ctrl +` and `ctrl
+            -`.
+        </p>
         <hr />
         <p><strong>Select a theme:</strong></p>
         <button
             v-for="theme in themes"
             :key="theme.slug"
             @click="setTheme(theme);"
-            class="theme"
+            class="option"
             :class="{ current: isCurrentTheme(theme) }"
         >
             {{ theme.name }}
@@ -50,40 +53,9 @@ export default {
 </script>
 
 <style lang="sass" rel="stylesheet/sass" scoped>
-.theme
-    position: relative
-    display: block
-    border: 0
-    background: transparent
-    padding: 10px 10px 10px 36px
-    font-size: 16px
-    cursor: pointer
-
-    &::before
-        content: ' '
-        position: absolute
-        left: 0
-        top: 50%
-        margin-top: -12px
-        width: 20px
-        height: 20px
-        border-radius: 50%
-        border: 2px solid $color-gray-lighter
-
-.current::after
-        content: ' '
-        position: absolute
-        left: 6px
-        top: 50%
-        margin-top: -6px
-        width: 12px
-        height: 12px
-        border-radius: 50%
-        background: $color-info
+.option
+    @extend %radio-option
 
 hr
-    height: 2px
-    background: $color-gray-lighter
-    border: 0
-    margin: 15px 0
+    @extend %line-break
 </style>

--- a/client/sass/_placeholders.sass
+++ b/client/sass/_placeholders.sass
@@ -1,0 +1,1 @@
+@import 'placeholders/form'

--- a/client/sass/globals.sass
+++ b/client/sass/globals.sass
@@ -1,3 +1,4 @@
 @import 'colors'
 @import 'variables'
 @import 'snippets'
+@import 'placeholders'

--- a/client/sass/placeholders/_form.sass
+++ b/client/sass/placeholders/_form.sass
@@ -1,0 +1,36 @@
+%radio-option
+    position: relative
+    display: block
+    border: 0
+    background: transparent
+    padding: 10px 10px 10px 36px
+    font-size: 16px
+    cursor: pointer
+
+    &::before
+        content: ' '
+        position: absolute
+        left: 0
+        top: 50%
+        margin-top: -12px
+        width: 20px
+        height: 20px
+        border-radius: 50%
+        border: 2px solid $color-gray-lighter
+
+    &.current::after
+            content: ' '
+            position: absolute
+            left: 6px
+            top: 50%
+            margin-top: -6px
+            width: 12px
+            height: 12px
+            border-radius: 50%
+            background: $color-info
+
+%line-break
+    height: 2px
+    background: $color-gray-lighter
+    border: 0
+    margin: 15px 0

--- a/client/store/StaticActions.js
+++ b/client/store/StaticActions.js
@@ -1,3 +1,4 @@
 export const SETTINGS_PANEL_TOGGLE = 'toggleSettingsPanel';
+export const SETTINGS_TOGGLE_NOTIFICATIONS = 'settingsToggleNotifications';
 
 export const CONTRIBUTOR_FETCH_CONTRIBUTORS = 'contributorFetchContributors';

--- a/client/store/StaticMutations.js
+++ b/client/store/StaticMutations.js
@@ -1,6 +1,8 @@
 export const SETTINGS_SET_PANEL_OPEN = 'settingsPanelSetOpen';
 export const SETTINGS_SET_PANEL_CLOSED = 'settingsPanelSetClosed';
 export const SETTINGS_SET_THEME = 'settingsSetTheme';
+export const SETTINGS_SET_NOTIFICATIONS_ON = 'settingsSetNotificationsOn';
+export const SETTINGS_SET_NOTIFICATIONS_OFF = 'settingsSetNotificationsOff';
 
 export const STATUS_SET_STATUSES = 'statusSetStatuses';
 

--- a/client/store/modules/SettingStore.js
+++ b/client/store/modules/SettingStore.js
@@ -1,9 +1,16 @@
-import { SETTINGS_PANEL_TOGGLE } from '../StaticActions';
-import { SETTINGS_SET_PANEL_OPEN, SETTINGS_SET_PANEL_CLOSED, SETTINGS_SET_THEME } from '../StaticMutations';
+import { SETTINGS_PANEL_TOGGLE, SETTINGS_TOGGLE_NOTIFICATIONS } from '../StaticActions';
+import {
+    SETTINGS_SET_PANEL_OPEN,
+    SETTINGS_SET_PANEL_CLOSED,
+    SETTINGS_SET_THEME,
+    SETTINGS_SET_NOTIFICATIONS_ON,
+    SETTINGS_SET_NOTIFICATIONS_OFF,
+} from '../StaticMutations';
 
 const state = {
     settingsPanelOpen: false,
     theme: 'basic-dark',
+    pushNotifications: false,
 };
 
 const getters = {};
@@ -11,6 +18,10 @@ const getters = {};
 const actions = {
     [SETTINGS_PANEL_TOGGLE]({ commit, state }) {
         commit(state.settingsPanelOpen ? SETTINGS_SET_PANEL_CLOSED : SETTINGS_SET_PANEL_OPEN);
+    },
+
+    [SETTINGS_TOGGLE_NOTIFICATIONS]({ commit, state }) {
+        commit(state.pushNotifications ? SETTINGS_SET_NOTIFICATIONS_OFF : SETTINGS_SET_NOTIFICATIONS_ON);
     },
 };
 
@@ -21,6 +32,14 @@ const mutations = {
 
     [SETTINGS_SET_PANEL_CLOSED](state) {
         state.settingsPanelOpen = false;
+    },
+
+    [SETTINGS_SET_NOTIFICATIONS_ON](state) {
+        state.pushNotifications = true;
+    },
+
+    [SETTINGS_SET_NOTIFICATIONS_OFF](state) {
+        state.pushNotifications = false;
     },
 
     [SETTINGS_SET_THEME](state, theme) {


### PR DESCRIPTION
### What

As a follow-up on @steefmin's [suggestion for desktop notifications](https://github.com/CIMonitor/CIMonitor/pull/64), I've now completely implemented it in the dashboard settings panel.

**Note:** By default the notifications are off. Enabling them will request permissions for push notifications.

![image](https://user-images.githubusercontent.com/6495166/49472153-fa74f680-f80e-11e8-8ab2-0e4e842a8b7b.png)
