### PR TITLE
Improve GitLab adapter, better build processing

### DIFF
--- a/back-end/domain/status/Status.js
+++ b/back-end/domain/status/Status.js
@@ -17,6 +17,14 @@ class Status {
         return this.data.state;
     }
 
+    getJobs() {
+        if (this.data.jobs) {
+            return this.data.jobs;
+        }
+
+        return [];
+    }
+
     isOld() {
         const oneWeekAgo = Moment().subtract(1, 'weeks');
         const statusTime = Moment(this.data.time);

--- a/back-end/domain/status/StatusFactory.js
+++ b/back-end/domain/status/StatusFactory.js
@@ -131,7 +131,9 @@ class StatusFactory {
             return StatusFactory.hydrateStatus(data);
         }
 
+        // Trash all jobs where the replacement job is pushed for
         data.jobs = data.jobs.filter(filterJob => filterJob.name !== job.name);
+        // Push updated job to the jobs list
         data.jobs.push(job);
 
         return StatusFactory.hydrateStatus(data);

--- a/back-end/domain/status/StatusFactory.js
+++ b/back-end/domain/status/StatusFactory.js
@@ -131,15 +131,9 @@ class StatusFactory {
             return StatusFactory.hydrateStatus(data);
         }
 
-        const existingJob = data.jobs.find(existingJob => existingJob.name === job.name);
-
-        if (existingJob) {
-            const index = data.jobs.indexOf(existingJob);
-            data.jobs[index] = job;
-            return StatusFactory.hydrateStatus(data);
-        }
-
+        data.jobs = data.jobs.filter(filterJob => filterJob.name !== job.name);
         data.jobs.push(job);
+
         return StatusFactory.hydrateStatus(data);
     }
 

--- a/back-end/domain/status/adapter/GitLab.js
+++ b/back-end/domain/status/adapter/GitLab.js
@@ -69,7 +69,7 @@ class StatusAdapterGitLab {
         status = StatusFactory.updateJob(status, {
             name: data.build_name,
             stage: data.build_stage,
-            state: this.buildStatusToState(data.build_status),
+            state: this.buildStatusToState(data.build_status, data.build_allow_failure),
         });
         StatusFactory.createStatus(status.getRawData());
     }
@@ -98,7 +98,7 @@ class StatusAdapterGitLab {
         return 'info';
     }
 
-    buildStatusToState(status) {
+    buildStatusToState(status, isFailureAllowed = false) {
         if (status === 'pending' || status === 'created') {
             return 'pending';
         }
@@ -108,7 +108,7 @@ class StatusAdapterGitLab {
         }
 
         if (status === 'failed') {
-            return 'error';
+            return isFailureAllowed ? 'warning' : 'error';
         }
 
         if (status === 'success') {

--- a/back-end/domain/status/adapter/GitLab.js
+++ b/back-end/domain/status/adapter/GitLab.js
@@ -6,11 +6,11 @@ class StatusAdapterGitLab {
     processWebHook(data) {
         switch (data.object_kind) {
             case 'pipeline':
-                this.processPipelineEvent(data);
-                break;
+                return this.processPipelineEvent(data);
             case 'build':
-                this.processBuildEvent(data);
-                break;
+                return this.processBuildEvent(data);
+            default:
+                return Promise.resolve('unprocessable-webhook-kind');
         }
     }
 
@@ -19,7 +19,7 @@ class StatusAdapterGitLab {
         const key = this.getKeyFromPipeline(data);
         let jobs = [];
 
-        // Clear the jobs when the pipeline status is pending (indicating a fresh pipeline)
+        // Use previous jobs if not pending, indicating a new/fresh pipeline
         if (data.object_attributes.status !== 'pending') {
             const existingStatus = StatusManager.getStatusByKey(key);
             if (existingStatus) {
@@ -27,7 +27,7 @@ class StatusAdapterGitLab {
             }
         }
 
-        StatusFactory.createStatus({
+        return StatusFactory.createStatus({
             key,
             state: this.pipelineStatusToState(data.object_attributes.status),
             title: data.project.path_with_namespace,
@@ -37,6 +37,31 @@ class StatusAdapterGitLab {
             stages: data.object_attributes.stages,
             jobs,
         });
+    }
+
+    processBuildEvent(data) {
+        const key = this.getKeyFromBuild(data);
+
+        // no one cares about created ¯\_(ツ)_/¯
+        if (data.build_status === 'created') {
+            console.log(`[StatusAdapterGitLab] Ignoring build created.`);
+            return Promise.resolve('ignore');
+        }
+
+        // Check if status key already exists, if not, ¯\_(ツ)_/¯
+        let status = StatusManager.getStatusByKey(key);
+        if (!status) {
+            console.log(`[StatusAdapterGitLab] Received build details for a pipeline that doesn't exist yet.`);
+            return Promise.resolve('ignore');
+        }
+
+        console.log('[StatusAdapterGitLab] Updating status with new build details...');
+        status = StatusFactory.updateJob(status, {
+            name: data.build_name,
+            stage: data.build_stage,
+            state: this.buildStatusToState(data.build_status, data.build_allow_failure),
+        });
+        return StatusFactory.createStatus(status.getRawData());
     }
 
     getProjectAvatar(data) {
@@ -49,31 +74,6 @@ class StatusAdapterGitLab {
         return data.project.avatar_url;
     }
 
-    processBuildEvent(data) {
-        const key = this.getKeyFromBuild(data);
-
-        // no one cares about created ¯\_(ツ)_/¯
-        if (data.build_status === 'created') {
-            console.log(`[StatusAdapterGitLab] Ignoring build created.`);
-            return;
-        }
-
-        // Check if status key already exists, if not, ¯\_(ツ)_/¯
-        let status = StatusManager.getStatusByKey(key);
-        if (!status) {
-            console.log(`[StatusAdapterGitLab] Received build details for a pipeline that doesn't exist yet.`);
-            return;
-        }
-
-        console.log('[StatusAdapterGitLab] Updating status with new build details...');
-        status = StatusFactory.updateJob(status, {
-            name: data.build_name,
-            stage: data.build_stage,
-            state: this.buildStatusToState(data.build_status, data.build_allow_failure),
-        });
-        StatusFactory.createStatus(status.getRawData());
-    }
-
     getKeyFromPipeline(data) {
         return `gitlab-${data.project.id}-${data.object_attributes.ref}`.replace(/[^\d\w-]/g, '-');
     }
@@ -83,39 +83,33 @@ class StatusAdapterGitLab {
     }
 
     pipelineStatusToState(status) {
-        if (status === 'running' || status === 'pending') {
-            return 'warning';
+        switch (status) {
+            case 'running':
+            case 'pending':
+                return 'warning';
+            case 'failed':
+                return 'error';
+            case 'success':
+                return 'success';
+            default:
+                return 'info';
         }
-
-        if (status === 'failed') {
-            return 'error';
-        }
-
-        if (status === 'success') {
-            return 'success';
-        }
-
-        return 'info';
     }
 
     buildStatusToState(status, isFailureAllowed = false) {
-        if (status === 'pending' || status === 'created') {
-            return 'pending';
+        switch (status) {
+            case 'pending':
+            case 'created':
+                return 'pending';
+            case 'running':
+                return 'running';
+            case 'failed':
+                return isFailureAllowed ? 'warning' : 'error';
+            case 'success':
+                return 'success';
+            default:
+                return 'info';
         }
-
-        if (status === 'running') {
-            return 'running';
-        }
-
-        if (status === 'failed') {
-            return isFailureAllowed ? 'warning' : 'error';
-        }
-
-        if (status === 'success') {
-            return 'success';
-        }
-
-        return 'info';
     }
 }
 

--- a/back-end/domain/status/adapter/TravisCI.js
+++ b/back-end/domain/status/adapter/TravisCI.js
@@ -7,10 +7,10 @@ class StatusAdapterTravisCI {
 
         // Do not process pull requests
         if (data.type === 'pull_request') {
-            return;
+            return Promise.resolve('no-pull-request');
         }
 
-        StatusFactory.createStatus({
+        return StatusFactory.createStatus({
             key: this.getKeyFromData(data),
             state: this.pipelineStatusToState(data.status_message),
             title: data.repository.owner_name + '/' + data.repository.name,

--- a/back-end/routes/webhook.js
+++ b/back-end/routes/webhook.js
@@ -8,19 +8,47 @@ app.use(express.urlencoded({ extended: true }));
 app.post('/gitlab', (request, response) => {
     console.log('/webhook/gitlab [POST]');
 
-    StatusAdapterGitLab.processWebHook(request.body);
+    StatusAdapterGitLab.processWebHook(request.body)
+        .then(status => {
+            if (status === 'ignore') {
+                return response.status(200).json({
+                    message: 'Received your web-hook, thank you for your service. Ignoring status.',
+                });
+            }
 
-    response.json({
-        message: 'Received your web-hook, thank you for your service.',
-    });
+            if (typeof status === 'object') {
+                return response.status(201).json({
+                    message: 'Received your web-hook, thank you for your service.',
+                    status: status.getRawData(),
+                });
+            }
+
+            response.status(422).json({
+                message: `CIMonitor only processes 'pipeline' and 'build' events.`,
+            });
+        })
+        .catch(error => {
+            response.status(500).json(error);
+        });
 });
 
 app.post('/travis', (request, response) => {
     console.log('/webhook/travis [POST]');
 
-    StatusAdapterTravisCI.processWebHook(request.body.payload);
+    StatusAdapterTravisCI.processWebHook(request.body.payload)
+        .then(status => {
+            if (status === 'no-pull-request') {
+                return response.status(422).json({
+                    message: 'Not processing PR builds.',
+                });
+            }
 
-    response.json({
-        message: 'Received your web-hook, thank you for your service.',
-    });
+            return response.status(201).json({
+                message: 'Received your web-hook, thank you for your service.',
+                status: status.getRawData(),
+            });
+        })
+        .catch(error => {
+            response.status(500).json(error);
+        });
 });

--- a/back-end/routes/webhook.js
+++ b/back-end/routes/webhook.js
@@ -12,13 +12,13 @@ app.post('/gitlab', (request, response) => {
         .then(status => {
             if (status === 'ignore') {
                 return response.status(200).json({
-                    message: 'Received your web-hook, thank you for your service. Ignoring status.',
+                    message: 'Received your webhook, thank you for your service. Ignoring status.',
                 });
             }
 
             if (typeof status === 'object') {
                 return response.status(201).json({
-                    message: 'Received your web-hook, thank you for your service.',
+                    message: 'Received your webhook, thank you for your service.',
                     status: status.getRawData(),
                 });
             }
@@ -44,7 +44,7 @@ app.post('/travis', (request, response) => {
             }
 
             return response.status(201).json({
-                message: 'Received your web-hook, thank you for your service.',
+                message: 'Received your webhook, thank you for your service.',
                 status: status.getRawData(),
             });
         })

--- a/front-end/components/Status/JobsAndStages/jobs-and-stages.vue
+++ b/front-end/components/Status/JobsAndStages/jobs-and-stages.vue
@@ -1,17 +1,12 @@
 <template>
     <div class="status__detail-jobs-and-stages">
         <div class="status__detail-stages" v-if="stages.length > 0">
-            <div
-                class="status__detail-stage"
-                :class="getStageStatus(stage)"
-                v-for="(stage, index) in stages"
-                :key="index"
-            >
+            <div class="status__detail-stage" :class="getStageStatus(stage)" v-for="stage in stages" :key="stage">
                 {{ stage }}
             </div>
         </div>
         <div class="status__detail-jobs" v-if="interestingJobs.length > 0">
-            <div class="status__detail-job" v-for="(job, index) in interestingJobs" :class="job.state" :key="index">
+            <div class="status__detail-job" v-for="job in interestingJobs" :class="job.state" :key="job.name">
                 {{ job.name }}
             </div>
         </div>

--- a/front-end/sass/themes/basic-dark.sass
+++ b/front-end/sass/themes/basic-dark.sass
@@ -56,8 +56,7 @@ $border-bottom: 3px
     .status__detail-title
         // pimary title
 
-    .status__detail-stages,
-    .status__detail-jobs
+    .status__detail-stages
         margin-top: 10px
 
     .status__detail-stage,

--- a/front-end/sass/themes/material-design.sass
+++ b/front-end/sass/themes/material-design.sass
@@ -22,7 +22,7 @@ $top-bar-height: 34px
 
         &::after
             position: absolute
-            left: 15px
+            left: 20px
             top: 3px
             font-size: 24px
             font:
@@ -94,8 +94,7 @@ $top-bar-height: 34px
     .status__detail-title
         // pimary title
 
-    .status__detail-stages,
-    .status__detail-jobs
+    .status__detail-stages
         margin-top: 10px
 
     .status__detail-stage,
@@ -140,7 +139,7 @@ $top-bar-height: 34px
 
     .status__time-ago
         position: absolute
-        right: 15px
+        right: 20px
         top: 3px
 
         &::before


### PR DESCRIPTION
### What

- Improve GitLab adapter, better build processing
- Return results out of the web hooks

### Why

The pipeline is pushing a list of all statuses, but those statuses aren't necessarily the latest jobs. This is causing confusion as the pipeline was successful, but a (already retried job) is showing failure. This PR improves that.