### PR TITLE
Fix issue that when searching for a status by key, they key is lower cased

### DIFF
--- a/back-end/domain/status/StatusManager.js
+++ b/back-end/domain/status/StatusManager.js
@@ -52,7 +52,7 @@ class StatusManager {
      * @return {Status}
      */
     getStatusByKey(statusKey) {
-        return this.statuses.find(status => status.getKey() === statusKey);
+        return this.statuses.find(status => status.getKey() === statusKey.toLowerCase());
     }
 
     getGlobalState() {


### PR DESCRIPTION
### What

Fix issue that when searching for a status by key, they key is lower cased.

### Why

For the GitLab adapter, job updates were not showing. This was due to the status manager not being able to find statuses where the key wasn't lower cased yet. This fix should resolve that issue.
