### PR TITLE
adds desktop notification filtering

### DIFF
--- a/front-end/components/SettingsPanel/panels/Notify/notify.vue
+++ b/front-end/components/SettingsPanel/panels/Notify/notify.vue
@@ -14,10 +14,10 @@
         <button class="option" @click="enableNotifications" :class="{ current: pushNotifications }">
             Enable desktop notifications
         </button>
-        <ul id="statusSelector">
+        <ul id="statusSelector" v-if="pushNotifications">
             <li v-for="(enabled, status) in notificationStatuses" :key="status">
                 <button class="sub-option" @click="toggleNotificationStatus(status);" :class="{ current: enabled }">
-                    Show {{ status }} statuses
+                    Show {{ status }}
                 </button>
             </li>
         </ul>
@@ -75,5 +75,5 @@ hr
 
 li
     list-style-type: none
-    padding-left: 20px
+    padding-left: 35px
 </style>

--- a/front-end/components/SettingsPanel/panels/Notify/notify.vue
+++ b/front-end/components/SettingsPanel/panels/Notify/notify.vue
@@ -14,12 +14,23 @@
         <button class="option" @click="enableNotifications" :class="{ current: pushNotifications }">
             Enable desktop notifications
         </button>
+        <ul id="statusSelector">
+            <li v-for="(enabled, status) in notificationStatuses" :key="status">
+                <button class="sub-option" @click="toggleNotificationStatus(status);" :class="{ current: enabled }">
+                    Show {{ status }} statuses
+                </button>
+            </li>
+        </ul>
     </div>
 </template>
 
 <script>
 import CIMonitorLogo from '../../../EmptyBoard/logo.png';
-import { SETTINGS_SET_NOTIFICATIONS_ON, SETTINGS_SET_NOTIFICATIONS_OFF } from '../../../../store/StaticMutations';
+import {
+    SETTINGS_SET_NOTIFICATIONS_ON,
+    SETTINGS_SET_NOTIFICATIONS_OFF,
+    SETTINGS_SET_NOTIFICATION_STATUSES,
+} from '../../../../store/StaticMutations';
 
 export default {
     methods: {
@@ -35,10 +46,18 @@ export default {
         dissableNotifications() {
             this.$store.commit(SETTINGS_SET_NOTIFICATIONS_OFF);
         },
+        toggleNotificationStatus(status) {
+            let statuses = this.$store.state.settings.notificationStatuses;
+            statuses[status] = !statuses[status];
+            this.$store.commit(SETTINGS_SET_NOTIFICATION_STATUSES, statuses);
+        },
     },
     computed: {
         pushNotifications() {
             return this.$store.state.settings.pushNotifications;
+        },
+        notificationStatuses() {
+            return this.$store.state.settings.notificationStatuses;
         },
     },
 };
@@ -48,6 +67,13 @@ export default {
 .option
     @extend %radio-option
 
+.sub-option
+    @extend %check-box
+
 hr
     @extend %line-break
+
+li
+    list-style-type: none
+    padding-left: 20px
 </style>

--- a/front-end/dashboard.js
+++ b/front-end/dashboard.js
@@ -35,6 +35,10 @@ new Vue({
                 return;
             }
 
+            if (!this.$store.state.settings.notificationStatuses[status.state]) {
+                return;
+            }
+
             try {
                 new Notification(`CIMonitor • ${status.state}`, {
                     body: `${status.title}${status.subTitle ? ` • ${status.subTitle}` : ''}: ${status.state}`,

--- a/front-end/sass/placeholders/_form.sass
+++ b/front-end/sass/placeholders/_form.sass
@@ -29,6 +29,36 @@
             border-radius: 50%
             background: $color-info
 
+%check-box
+    position: relative
+    display: block
+    border: 0
+    background: transparent
+    padding: 10px 10px 10px 36px
+    font-size: 16px
+
+    &::before
+        content: ' '
+        position: absolute
+        left: 0
+        top: 50%
+        margin-top: -12px
+        width: 20px
+        height: 20px
+        border-radius: 50%
+        border: 2px solid $color-gray-lighter
+
+    &.current::after
+        content: ' '
+        position: absolute
+        left: 6px
+        top: 50%
+        margin-top: -6px
+        width: 12px
+        height: 12px
+        border-radius: 50%
+        background: $color-info
+
 %line-break
     height: 2px
     background: $color-gray-lighter

--- a/front-end/sass/placeholders/_form.sass
+++ b/front-end/sass/placeholders/_form.sass
@@ -45,7 +45,6 @@
         margin-top: -12px
         width: 20px
         height: 20px
-        border-radius: 50%
         border: 2px solid $color-gray-lighter
 
     &.current::after
@@ -56,7 +55,6 @@
         margin-top: -6px
         width: 12px
         height: 12px
-        border-radius: 50%
         background: $color-info
 
 %line-break

--- a/front-end/store/StaticMutations.js
+++ b/front-end/store/StaticMutations.js
@@ -3,6 +3,7 @@ export const SETTINGS_SET_PANEL_CLOSED = 'settingsPanelSetClosed';
 export const SETTINGS_SET_THEME = 'settingsSetTheme';
 export const SETTINGS_SET_NOTIFICATIONS_ON = 'settingsSetNotificationsOn';
 export const SETTINGS_SET_NOTIFICATIONS_OFF = 'settingsSetNotificationsOff';
+export const SETTINGS_SET_NOTIFICATION_STATUSES = 'settingsSetNotificationStatuses';
 
 export const STATUS_SET_STATUSES = 'statusSetStatuses';
 

--- a/front-end/store/modules/SettingStore.js
+++ b/front-end/store/modules/SettingStore.js
@@ -13,8 +13,8 @@ const state = {
     theme: 'basic-dark',
     pushNotifications: false,
     notificationStatuses: {
-        info: false,
-        warning: false,
+        info: true,
+        warning: true,
         error: true,
         success: true,
     },
@@ -29,10 +29,6 @@ const actions = {
 
     [SETTINGS_TOGGLE_NOTIFICATIONS]({ commit, state }) {
         commit(state.pushNotifications ? SETTINGS_SET_NOTIFICATIONS_OFF : SETTINGS_SET_NOTIFICATIONS_ON);
-    },
-
-    [SETTINGS_SET_NOTIFICATION_STATUSES]({ commit, state }) {
-        commit(state.notificationStatuses);
     },
 };
 

--- a/front-end/store/modules/SettingStore.js
+++ b/front-end/store/modules/SettingStore.js
@@ -5,12 +5,19 @@ import {
     SETTINGS_SET_THEME,
     SETTINGS_SET_NOTIFICATIONS_ON,
     SETTINGS_SET_NOTIFICATIONS_OFF,
+    SETTINGS_SET_NOTIFICATION_STATUSES,
 } from '../StaticMutations';
 
 const state = {
     settingsPanelOpen: false,
     theme: 'basic-dark',
     pushNotifications: false,
+    notificationStatuses: {
+        info: false,
+        warning: false,
+        error: true,
+        success: true,
+    },
 };
 
 const getters = {};
@@ -22,6 +29,10 @@ const actions = {
 
     [SETTINGS_TOGGLE_NOTIFICATIONS]({ commit, state }) {
         commit(state.pushNotifications ? SETTINGS_SET_NOTIFICATIONS_OFF : SETTINGS_SET_NOTIFICATIONS_ON);
+    },
+
+    [SETTINGS_SET_NOTIFICATION_STATUSES]({ commit, state }) {
+        commit(state.notificationStatuses);
     },
 };
 
@@ -44,6 +55,10 @@ const mutations = {
 
     [SETTINGS_SET_THEME](state, theme) {
         state.theme = theme;
+    },
+
+    [SETTINGS_SET_NOTIFICATION_STATUSES](state, statuses) {
+        state.notificationStatuses = statuses;
     },
 };
 


### PR DESCRIPTION
### What

This PR adds filtering to the desktop notification functionality added in #64. 

### Why

Currently, when the desktop notifications are enabled, you will receive a notification of each update of the status of your pipeline. However most users are only interested in two of the cases: 
- the success of your pipeline
and even more important
- a failed pipeline

This PR allows you to select which statuses you want to be notified of. By default the 'error' and 'success' states will be notified, the others are disabled. 