### PR TITLE
adds deployer adapter

### DIFF
--- a/back-end/domain/status/adapter/Deployer.js
+++ b/back-end/domain/status/adapter/Deployer.js
@@ -1,0 +1,29 @@
+const StatusFactory = require('../StatusFactory');
+const gravatar = require('gravatar');
+
+class StatusAdapterDeployer {
+    processWebHook(data) {
+        data = JSON.parse(data);
+        var statuses = ['info', 'warning', 'error', 'success'];
+
+        // Do not process unknown statuses
+        if (!statuses.includes(data.state)) {
+            return Promise.resolve('unknown-status');
+        }
+
+        return StatusFactory.createStatus({
+            key: this.getKeyFromData(data),
+            state: data.state,
+            title: data.title,
+            subTitle: data.branch,
+            stage: data.stage,
+            userImage: gravatar.url(data.user.email, null, true),
+        });
+    }
+
+    getKeyFromData(data) {
+        return `deployer-${data.title}-${data.branch}-${data.stage}-${data.user.name}`;
+    }
+}
+
+module.exports = new StatusAdapterDeployer();

--- a/back-end/domain/status/adapter/Deployer.js
+++ b/back-end/domain/status/adapter/Deployer.js
@@ -16,13 +16,14 @@ class StatusAdapterDeployer {
             state: data.state,
             title: data.title,
             subTitle: data.branch,
-            stage: data.stage,
+            stages: data.stages,
+            jobs: data.jobs,
             userImage: gravatar.url(data.user.email, null, true),
         });
     }
 
     getKeyFromData(data) {
-        return `deployer-${data.title}-${data.branch}-${data.stage}-${data.user.name}`;
+        return `deployer-${data.title}-${data.branch}-${data.user.name}`.replace(/[^\w-]/g, '-');
     }
 }
 

--- a/back-end/routes/webhook.js
+++ b/back-end/routes/webhook.js
@@ -2,6 +2,7 @@ const express = require('express');
 const app = (module.exports = express());
 const StatusAdapterGitLab = require('../domain/status/adapter/GitLab');
 const StatusAdapterTravisCI = require('../domain/status/adapter/TravisCI');
+const StatusAdapterDeployer = require('../domain/status/adapter/Deployer');
 
 app.use(express.urlencoded({ extended: true }));
 
@@ -40,6 +41,27 @@ app.post('/travis', (request, response) => {
             if (status === 'no-pull-request') {
                 return response.status(422).json({
                     message: 'Not processing PR builds.',
+                });
+            }
+
+            return response.status(201).json({
+                message: 'Received your webhook, thank you for your service.',
+                status: status.getRawData(),
+            });
+        })
+        .catch(error => {
+            response.status(500).json(error);
+        });
+});
+
+app.post('/deployer', (request, response) => {
+    console.log('/webhook/deployer [POST]');
+
+    StatusAdapterDeployer.processWebHook(request.body.payload)
+        .then(status => {
+            if (status === 'unknown-status') {
+                return response.status(422).json({
+                    message: 'Not processing unknown statuses.',
                 });
             }
 

--- a/cypress/fixtures/deployer-recipe/1.json
+++ b/cypress/fixtures/deployer-recipe/1.json
@@ -1,0 +1,17 @@
+{
+    "state": "warning",
+    "branch": "deployer-adapter",
+    "title": "steefmin/CIMonitor",
+    "user": {
+        "name": "Steef Min",
+        "email": "smin@enrise.com"
+    },
+    "stages": [
+        "Production"
+    ],
+    "jobs": [{
+        "name": "Deploying...",
+        "stage": "",
+        "state": "running"
+    }]
+}

--- a/cypress/fixtures/deployer-recipe/2.json
+++ b/cypress/fixtures/deployer-recipe/2.json
@@ -1,0 +1,17 @@
+{
+    "state": "error",
+    "branch": "deployer-adapter",
+    "title": "steefmin/CIMonitor",
+    "user": {
+        "name": "Steef Min",
+        "email": "smin@enrise.com"
+    },
+    "stages": [
+        "Production"
+    ],
+    "jobs": [{
+        "name": "Deploy",
+        "stage": "",
+        "state": "error"
+    }]
+}

--- a/cypress/fixtures/deployer-recipe/3.json
+++ b/cypress/fixtures/deployer-recipe/3.json
@@ -1,0 +1,17 @@
+{
+    "state": "success",
+    "branch": "deployer-adapter",
+    "title": "steefmin/CIMonitor",
+    "user": {
+        "name": "Steef Min",
+        "email": "smin@enrise.com"
+    },
+    "stages": [
+        "Deployed to Production"
+    ],
+    "jobs": [{
+        "name": "Deploy",
+        "stage": "Deployed to Production",
+        "state": "success"
+    }]
+}

--- a/cypress/integration/dashboard-deployer-recipe.spec.js
+++ b/cypress/integration/dashboard-deployer-recipe.spec.js
@@ -1,0 +1,12 @@
+context('Deployer Recipe', () => {
+    it('opens the dashboard', () => {
+        cy.visit('/');
+    });
+
+    it('pushes successful Deployer results', () => {
+        for (let i = 1; i <= 3; i++) {
+            cy.pushDeployerWebhook(`${i}.json`);
+            cy.wait(1000);
+        }
+    });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -41,3 +41,18 @@ Cypress.Commands.add('pushTravisCIWebhook', request => {
         });
     });
 });
+
+Cypress.Commands.add('pushDeployerWebhook', request => {
+    cy.fixture(`deployer-recipe/${request}`).then(body => {
+        cy.request({
+            url: 'http://localhost:9999/webhook/deployer',
+            method: 'POST',
+            body: {
+                payload: JSON.stringify(body),
+            },
+            headers: {
+                'Content-Type': 'application/json',
+            },
+        });
+    });
+});

--- a/docs/services/Deployer.md
+++ b/docs/services/Deployer.md
@@ -37,7 +37,7 @@ before('deploy', 'cimonitor:notify');
 ```
 
 Secondly define the updates on succes and failure of the deployment (recommended):
-```$xslt
+```
 after('success', 'cimonitor:notify:success');
 after('deploy:failed', 'cimonitor:notify:failure');
 ```

--- a/docs/services/Deployer.md
+++ b/docs/services/Deployer.md
@@ -1,0 +1,49 @@
+# Deployer
+
+[Deployer](https://deployer.org) is a deployment tool for PHP projects. CIMonitor can support updates from the 
+deployments that are issued with this tool.
+
+## Setup deployer recipe
+
+Note: at time of writing the recipe for CIMonitor is in review stage. Documentation can be found at 
+https://github.com/steefmin/recipes/blob/40b2950b9178c6c291b3583477ccbc4bdb5160d5/docs/cimonitor.md. When/if it is 
+approved, it can be found at https://deployer.org/recipes. 
+
+### Installing
+
+- Install the third-party recipes package with composer
+
+```
+composer require deployer/recipes --dev
+```
+
+- Include the recipe in your `deploy.php`
+
+```
+require 'recipe/cimonitor.php';
+```
+
+
+### Minimal setup
+For minimum setup, you need to set the host and endpoint of you CIMonitor server in your deploy.php. Deployer will send 
+the updates to this location. 
+
+```
+set('cimonitor_webhook', 'https://cimonitor.enrise.com/webhook/deployer');
+```
+
+To use the actual tasks, define them in your `deploy.php`
+
+First define to send notification of a started deployment to CIMonitor with (optional):
+```
+before('deploy', 'cimonitor:notify');
+```
+
+Secondly define the updates on succes and failure of the deployment (recommended):
+```$xslt
+after('success', 'cimonitor:notify:success');
+after('deploy:failed', 'cimonitor:notify:failure');
+```
+
+### Advanced
+For advanced settings in your Deployer scripts, see https://deployer.org/recipes. 

--- a/docs/services/Deployer.md
+++ b/docs/services/Deployer.md
@@ -21,7 +21,6 @@ composer require deployer/recipes --dev
 require 'recipe/cimonitor.php';
 ```
 
-
 ### Minimal setup
 For minimum setup, you need to set the host and endpoint of you CIMonitor server in your deploy.php. Deployer will send 
 the updates to this location. 

--- a/docs/services/Deployer.md
+++ b/docs/services/Deployer.md
@@ -5,9 +5,7 @@ deployments that are issued with this tool.
 
 ## Setup deployer recipe
 
-Note: at time of writing the recipe for CIMonitor is in review stage. Documentation can be found at 
-https://github.com/steefmin/recipes/blob/40b2950b9178c6c291b3583477ccbc4bdb5160d5/docs/cimonitor.md. When/if it is 
-approved, it can be found at https://deployer.org/recipes. 
+Documentation for setting up the deployer recipe can be found at https://deployer.org/recipes/cimonitor.
 
 ### Installing
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ pages:
     - Link a service:
           - GitLab: services/GitLab.md
           - Travis CI: services/Travis-CI.md
+          - Deployer: services/Deployer.md
     - Modules:
           - Marble run: modules/marble-run.md
           - Dashboard video: modules/dashboard-video.md


### PR DESCRIPTION
### What

This PR adds an adapter for Deployer (deployer.org) calls. 

### Why

For deployments that are not performed from Gitlab, it is nice to also have the status displayed on CIMonitor. This adds the required adapter for receiving the calls from the deployer recipe from deployerphp/recipes#204
