### PR TITLE
Add automated old status cleaning interval every hour

### DIFF
--- a/back-end/domain/status/StatusManager.js
+++ b/back-end/domain/status/StatusManager.js
@@ -7,7 +7,7 @@ class StatusManager {
 
         this.setListeners();
 
-        setInterval(() => this.checkForOldStatuses(), 1000 * 60 * 60);
+        setInterval(() => this.removeOldStatuses(), 1000 * 60 * 60);
     }
 
     setListeners() {
@@ -70,13 +70,9 @@ class StatusManager {
     }
 
     removeOldStatuses() {
-        this.statuses = this.statuses.filter(status => !status.isOld());
-    }
-
-    checkForOldStatuses() {
         const statusCount = this.statuses.length;
 
-        this.removeOldStatuses();
+        this.statuses = this.statuses.filter(status => !status.isOld());
 
         // If statuses are removed, push that the statuses are updated
         if (this.statuses.length < statusCount) {
@@ -93,8 +89,6 @@ class StatusManager {
 
         this.processStatus(status);
 
-        this.removeOldStatuses();
-
         Events.push(Events.event.statusesUpdated);
     }
 
@@ -110,8 +104,6 @@ class StatusManager {
     }
 
     removeStatus(statusKey) {
-        this.removeOldStatuses();
-
         const existingStatus = this.statuses.find(existingStatus => existingStatus.getKey() === statusKey);
 
         if (existingStatus) {

--- a/back-end/domain/status/StatusManager.js
+++ b/back-end/domain/status/StatusManager.js
@@ -6,6 +6,8 @@ class StatusManager {
         this.statuses = [];
 
         this.setListeners();
+
+        setInterval(() => this.checkForOldStatuses(), 1000 * 60 * 60);
     }
 
     setListeners() {
@@ -69,6 +71,18 @@ class StatusManager {
 
     removeOldStatuses() {
         this.statuses = this.statuses.filter(status => !status.isOld());
+    }
+
+    checkForOldStatuses() {
+        const statusCount = this.statuses.length;
+
+        this.removeOldStatuses();
+
+        // If statuses are removed, push that the statuses are updated
+        if (this.statuses.length < statusCount) {
+            console.log('[StatusManager] Old statuses have been removed.');
+            Events.push(Events.event.statusesUpdated);
+        }
     }
 
     /**


### PR DESCRIPTION
### What

Add automated old status cleaning interval every hour.

### Why

- Statuses were only removed when a new event was pushed. If nothing was pushed for 1 weeks, old statuses would still show on the dashboard. These are now automatically removed after their expire time (which is 1 week currently)
