### PR TITLE
Hide mouse pointer after X miliseconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /config/config.json
 /Dockerfile
 /.dockerignore
+/docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /Dockerfile
 /.dockerignore
 /docker-compose.yml
+/yarn-error.log

--- a/front-end/components/SettingsPanel/panels/Personalize/personalize.vue
+++ b/front-end/components/SettingsPanel/panels/Personalize/personalize.vue
@@ -7,15 +7,14 @@
         </p>
         <p><strong>Hide cursor:</strong></p>
         <button class="option" @click="disableCursorHide" :class="{ current: !cursorHidden }">Don't hide cursor</button>
-        <button class="option" @click="enableCursorHide" :class="{ current: cursorHidden }">Hide cursor after:</button>
+        <button class="option" @click="enableCursorHide" :class="{ current: cursorHidden }">Hide cursor</button>
         <div id="cursorHiddenTimeout" v-if="cursorHidden">
-            <input v-model.number="cursorHiddenTimeout" type="number" class="text" /> Miliseconds
+            Hide after <input v-model.number="cursorHiddenTimeout" type="number" class="text" /> miliseconds
         </div>
     </div>
 </template>
 
 <script>
-import CIMonitorLogo from '../../../EmptyBoard/logo.png';
 import {
     SETTINGS_SET_CURSORHIDDEN_ON,
     SETTINGS_SET_CURSORHIDDEN_OFF,
@@ -25,21 +24,9 @@ import {
 export default {
     methods: {
         enableCursorHide() {
-            Notification.requestPermission().then(() => {
-                new Notification(`CIMonitor`, {
-                    body: `Hiding of cursor enabled!`,
-                    icon: CIMonitorLogo,
-                });
-            });
             this.$store.commit(SETTINGS_SET_CURSORHIDDEN_ON);
         },
         disableCursorHide() {
-            Notification.requestPermission().then(() => {
-                new Notification(`CIMonitor`, {
-                    body: `Hiding of cursor enabled!`,
-                    icon: CIMonitorLogo,
-                });
-            });
             this.$store.commit(SETTINGS_SET_CURSORHIDDEN_OFF);
         },
     },

--- a/front-end/components/SettingsPanel/panels/Personalize/personalize.vue
+++ b/front-end/components/SettingsPanel/panels/Personalize/personalize.vue
@@ -5,11 +5,67 @@
             To increase the size of the dashboard, please use the built in zoom functionality using `ctrl +` and `ctrl
             -`.
         </p>
+        <p><strong>Hide cursor:</strong></p>
+        <button class="option" @click="disableCursorHide" :class="{ current: !cursorHidden }">Don't hide cursor</button>
+        <button class="option" @click="enableCursorHide" :class="{ current: cursorHidden }">Hide cursor after:</button>
+        <div id="cursorHiddenTimeout" v-if="cursorHidden">
+            <input v-model.number="cursorHiddenTimeout" type="number" class="text" /> Miliseconds
+        </div>
     </div>
 </template>
 
 <script>
-export default {};
+import CIMonitorLogo from '../../../EmptyBoard/logo.png';
+import {
+    SETTINGS_SET_CURSORHIDDEN_ON,
+    SETTINGS_SET_CURSORHIDDEN_OFF,
+    SETTINGS_SET_CURSORHIDDEN_TIMEOUT,
+} from '../../../../store/StaticMutations';
+
+export default {
+    methods: {
+        enableCursorHide() {
+            Notification.requestPermission().then(() => {
+                new Notification(`CIMonitor`, {
+                    body: `Hiding of cursor enabled!`,
+                    icon: CIMonitorLogo,
+                });
+            });
+            this.$store.commit(SETTINGS_SET_CURSORHIDDEN_ON);
+        },
+        disableCursorHide() {
+            Notification.requestPermission().then(() => {
+                new Notification(`CIMonitor`, {
+                    body: `Hiding of cursor enabled!`,
+                    icon: CIMonitorLogo,
+                });
+            });
+            this.$store.commit(SETTINGS_SET_CURSORHIDDEN_OFF);
+        },
+    },
+    computed: {
+        cursorHidden() {
+            return this.$store.state.settings.cursorHidden;
+        },
+        cursorHiddenTimeout: {
+            get: function() {
+                return this.$store.state.settings.cursorHiddenTimeout;
+            },
+            set: function(timeout) {
+                this.$store.commit(SETTINGS_SET_CURSORHIDDEN_TIMEOUT, timeout);
+            },
+        },
+    },
+};
 </script>
 
-<style lang="sass" rel="stylesheet/sass" scoped></style>
+<style lang="sass" rel="stylesheet/sass" scoped>
+#cursorHiddenTimeout
+    padding-left: 36px
+
+.option
+    @extend %radio-option
+
+.text
+    @extend %input-text
+</style>

--- a/front-end/dashboard.js
+++ b/front-end/dashboard.js
@@ -54,28 +54,22 @@ new Vue({
         },
         cursorHide() {
             let cursorTimer;
-            document.body.addEventListener(
-                'mousemove',
-                function(e) {
-                    if (e.movementY > 0 || e.movementX > 0) {
-                        window.clearTimeout(cursorTimer);
-                        document.body.style.cursor = null;
-                        if (this.$store.state.settings.cursorHidden) {
-                            cursorTimer = window.setTimeout(function() {
-                                document.body.style.cursor = 'none';
-                            }, this.$store.state.settings.cursorHiddenTimeout);
-                        }
-                    }
-                }.bind(this)
-            );
-            cursorTimer = window.setTimeout(
-                function() {
+            document.body.addEventListener('mousemove', event => {
+                if (event.movementY > 0 || event.movementX > 0) {
+                    window.clearTimeout(cursorTimer);
+                    document.body.style.cursor = null;
                     if (this.$store.state.settings.cursorHidden) {
-                        document.body.style.cursor = 'none';
+                        cursorTimer = window.setTimeout(function() {
+                            document.body.style.cursor = 'none';
+                        }, this.$store.state.settings.cursorHiddenTimeout);
                     }
-                }.bind(this),
-                this.$store.state.settings.cursorHiddenTimeout
-            );
+                }
+            });
+            cursorTimer = window.setTimeout(() => {
+                if (this.$store.state.settings.cursorHidden) {
+                    document.body.style.cursor = 'none';
+                }
+            }, this.$store.state.settings.cursorHiddenTimeout);
         },
     },
     sockets: {

--- a/front-end/dashboard.js
+++ b/front-end/dashboard.js
@@ -59,7 +59,7 @@ new Vue({
                     window.clearTimeout(cursorTimer);
                     document.body.style.cursor = null;
                     if (this.$store.state.settings.cursorHidden) {
-                        cursorTimer = window.setTimeout(function() {
+                        cursorTimer = window.setTimeout(() => {
                             document.body.style.cursor = 'none';
                         }, this.$store.state.settings.cursorHiddenTimeout);
                     }

--- a/front-end/dashboard.js
+++ b/front-end/dashboard.js
@@ -26,6 +26,7 @@ new Vue({
     },
     created() {
         document.title = `CIMonitor | ${location.host}`;
+        this.cursorHide();
     },
     methods: {
         updateFavicon(globalState) {
@@ -50,6 +51,31 @@ new Vue({
             } catch (error) {
                 // do nothing.
             }
+        },
+        cursorHide() {
+            let cursorTimer;
+            document.body.addEventListener(
+                'mousemove',
+                function(e) {
+                    if (e.movementY > 0 || e.movementX > 0) {
+                        window.clearTimeout(cursorTimer);
+                        document.body.style.cursor = null;
+                        if (this.$store.state.settings.cursorHidden) {
+                            cursorTimer = window.setTimeout(function() {
+                                document.body.style.cursor = 'none';
+                            }, this.$store.state.settings.cursorHiddenTimeout);
+                        }
+                    }
+                }.bind(this)
+            );
+            cursorTimer = window.setTimeout(
+                function() {
+                    if (this.$store.state.settings.cursorHidden) {
+                        document.body.style.cursor = 'none';
+                    }
+                }.bind(this),
+                this.$store.state.settings.cursorHiddenTimeout
+            );
         },
     },
     sockets: {

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -24,19 +24,23 @@
         </script>
         <script type="text/javascript" src="/dashboard.js?bust=---bust---"></script>
         <script type="text/javascript">
-            let cursorTimer;
-            document.body.addEventListener("mousemove", function (e) {
-                if (e.movementY > 0 || e.movementX > 0) {
-                    window.clearTimeout(cursorTimer);
-                    document.body.style.cursor = null;
-                    cursorTimer = window.setTimeout(function() {
-                        document.body.style.cursor = 'none';
-                    }, 5000)
-                }
-            });
-            cursorTimer = window.setTimeout(function() {
-                document.body.style.cursor = 'none';
-            }, 5000)
+            (function() {
+                'use strict';
+
+                let cursorTimer;
+                document.body.addEventListener("mousemove", function (e) {
+                    if (e.movementY > 0 || e.movementX > 0) {
+                        window.clearTimeout(cursorTimer);
+                        document.body.style.cursor = null;
+                        cursorTimer = window.setTimeout(function() {
+                            document.body.style.cursor = 'none';
+                        }, 5000)
+                    }
+                });
+                cursorTimer = window.setTimeout(function() {
+                    document.body.style.cursor = 'none';
+                }, 5000)
+            })();
         </script>
     </body>
 </html>

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -23,24 +23,5 @@
             window.CIMonitorVersion = '---version---';
         </script>
         <script type="text/javascript" src="/dashboard.js?bust=---bust---"></script>
-        <script type="text/javascript">
-            (function() {
-                'use strict';
-
-                let cursorTimer;
-                document.body.addEventListener("mousemove", function (e) {
-                    if (e.movementY > 0 || e.movementX > 0) {
-                        window.clearTimeout(cursorTimer);
-                        document.body.style.cursor = null;
-                        cursorTimer = window.setTimeout(function() {
-                            document.body.style.cursor = 'none';
-                        }, 5000)
-                    }
-                });
-                cursorTimer = window.setTimeout(function() {
-                    document.body.style.cursor = 'none';
-                }, 5000)
-            })();
-        </script>
     </body>
 </html>

--- a/front-end/index.html
+++ b/front-end/index.html
@@ -23,5 +23,20 @@
             window.CIMonitorVersion = '---version---';
         </script>
         <script type="text/javascript" src="/dashboard.js?bust=---bust---"></script>
+        <script type="text/javascript">
+            let cursorTimer;
+            document.body.addEventListener("mousemove", function (e) {
+                if (e.movementY > 0 || e.movementX > 0) {
+                    window.clearTimeout(cursorTimer);
+                    document.body.style.cursor = null;
+                    cursorTimer = window.setTimeout(function() {
+                        document.body.style.cursor = 'none';
+                    }, 5000)
+                }
+            });
+            cursorTimer = window.setTimeout(function() {
+                document.body.style.cursor = 'none';
+            }, 5000)
+        </script>
     </body>
 </html>

--- a/front-end/sass/placeholders/_form.sass
+++ b/front-end/sass/placeholders/_form.sass
@@ -57,6 +57,13 @@
         height: 12px
         background: $color-info
 
+%input-text
+    display: inline-block
+    padding: 8px 10px
+    border: 2px solid $color-gray-lighter
+    border-radius: 5px
+    font-size: 16px
+
 %line-break
     height: 2px
     background: $color-gray-lighter

--- a/front-end/store/StaticMutations.js
+++ b/front-end/store/StaticMutations.js
@@ -3,6 +3,9 @@ export const SETTINGS_SET_PANEL_CLOSED = 'settingsPanelSetClosed';
 export const SETTINGS_SET_NOTIFICATIONS_ON = 'settingsSetNotificationsOn';
 export const SETTINGS_SET_NOTIFICATIONS_OFF = 'settingsSetNotificationsOff';
 export const SETTINGS_SET_NOTIFICATION_STATUSES = 'settingsSetNotificationStatuses';
+export const SETTINGS_SET_CURSORHIDDEN_ON = 'settingsSetCursorHiddenOn';
+export const SETTINGS_SET_CURSORHIDDEN_OFF = 'settingsSetCursorHiddenOff';
+export const SETTINGS_SET_CURSORHIDDEN_TIMEOUT = 'settingsSetCursorHiddenTimeout';
 
 export const STATUS_SET_STATUSES = 'statusSetStatuses';
 

--- a/front-end/store/modules/SettingStore.js
+++ b/front-end/store/modules/SettingStore.js
@@ -5,6 +5,9 @@ import {
     SETTINGS_SET_NOTIFICATIONS_ON,
     SETTINGS_SET_NOTIFICATIONS_OFF,
     SETTINGS_SET_NOTIFICATION_STATUSES,
+    SETTINGS_SET_CURSORHIDDEN_ON,
+    SETTINGS_SET_CURSORHIDDEN_OFF,
+    SETTINGS_SET_CURSORHIDDEN_TIMEOUT,
 } from '../StaticMutations';
 
 const state = {
@@ -16,6 +19,8 @@ const state = {
         error: true,
         success: true,
     },
+    cursorHidden: false,
+    cursorHiddenTimeout: 5000,
 };
 
 const getters = {};
@@ -49,6 +54,18 @@ const mutations = {
 
     [SETTINGS_SET_NOTIFICATION_STATUSES](state, statuses) {
         state.notificationStatuses = statuses;
+    },
+
+    [SETTINGS_SET_CURSORHIDDEN_ON](state) {
+        state.cursorHidden = true;
+    },
+
+    [SETTINGS_SET_CURSORHIDDEN_OFF](state) {
+        state.cursorHidden = false;
+    },
+
+    [SETTINGS_SET_CURSORHIDDEN_TIMEOUT](state, timeout) {
+        state.cursorHiddenTimeout = timeout;
     },
 };
 


### PR DESCRIPTION
### What

This PR adds a configuration option to hide the mouse cursor after X miliseconds of not moving, and shows it again when moving.

### Why

Even though a program like [unclutter](http://manpages.ubuntu.com/manpages/bionic/man1/unclutter.1.html) exists, this method works without dependencies.
I chose to use the CSS way, since the Cursor Lock API has the huge downside of needing user interaction for it to work.
