### PR TITLE
Fix loading data from Firebase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@
 /.dockerignore
 /docker-compose.yml
 /yarn-error.log
+
+# Files needed to use Firebase as a backend. See the README for more info.
 .env
 config/serviceAccountKey.json

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /.dockerignore
 /docker-compose.yml
 /yarn-error.log
+.env
+config/serviceAccountKey.json

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ To start development run:
 
 Note: The server needs to run in order to display the dashboard.
 
+### Using Firebase as a backend
+
+To start development when using Firebase as a backend:
+
+-   Set up a Firebase database (see the online documentation)
+-   Store the generated JSON file in `config/serviceAccountKey.json`
+-   Copy .env.example to .env and update with the right values
+-   Start the server as normal, it will now use Firebase as storage backend
+
 ## Running production
 
 To start the production build:

--- a/back-end/config/loader/AbstractConfigLoader.js
+++ b/back-end/config/loader/AbstractConfigLoader.js
@@ -7,44 +7,60 @@ class AbstractConfigLoader {
         throw new Error('Implement loadConfig()');
     }
 
-    validateConfig(config) {
-        if (typeof config !== 'object' || config === null) {
+    getConfig() {
+        return this.config;
+    }
+
+    setConfigDefaults(config) {
+        if (this.isNotAnObject(config)) {
             throw new Error('Loaded config is not an object');
         }
 
-        if (!('triggers' in config) || !Array.isArray(config.triggers)) {
+        if (this.isNotanArray(config.triggers)) {
+            config.triggers = [];
+        }
+
+        if (this.isNotanArray(config.events)) {
+            config.events = [];
+        }
+
+        if (this.isNotanArray(config.modules)) {
+            config.modules = [];
+        }
+    }
+
+    validateConfig(config) {
+        if (this.isNotAnObject(config)) {
+            throw new Error('Loaded config is not an object');
+        }
+
+        if (this.isNotanArray(config.triggers)) {
             throw new Error('Loaded config section invalid: triggers');
         }
 
-        if (!('events' in config) || !Array.isArray(config.events)) {
+        if (this.isNotanArray(config.events)) {
             throw new Error('Loaded config section invalid: events');
         }
 
-        if (!('modules' in config) || !Array.isArray(config.modules)) {
+        if (this.isNotanArray(config.modules)) {
             throw new Error('Loaded config section invalid: modules');
         }
 
-        if (
-            !('server' in config) ||
-            Array.isArray(config.server) ||
-            typeof config.server !== 'object' ||
-            config.server === null
-        ) {
+        if (this.isNotAnObject(config.server)) {
             throw new Error('Loaded config section invalid: server');
         }
 
-        if (
-            !('moduleClient' in config) ||
-            Array.isArray(config.moduleClient) ||
-            typeof config.moduleClient !== 'object' ||
-            config.moduleClient === null
-        ) {
+        if (this.isNotAnObject(config.moduleClient)) {
             throw new Error('Loaded config section invalid: moduleClient');
         }
     }
 
-    getConfig() {
-        return this.config;
+    isNotAnObject(value) {
+        return typeof value !== 'object' || value === null || Array.isArray(value);
+    }
+
+    isNotanArray(value) {
+        return !Array.isArray(value);
     }
 }
 

--- a/back-end/config/loader/Filesystem.js
+++ b/back-end/config/loader/Filesystem.js
@@ -11,6 +11,7 @@ class Filesystem extends AbstractConfigLoader {
         try {
             const config = this.loadConfigFromFilesystem();
 
+            this.setConfigDefaults(config);
             this.validateConfig(config);
 
             this.config = new Config(

--- a/back-end/config/loader/Filesystem.test.js
+++ b/back-end/config/loader/Filesystem.test.js
@@ -27,7 +27,7 @@ test.each(invalidObjects)('An error is thrown if the config is %s', async (descr
 
     await FilesystemConfigLoader.loadConfig();
 
-    expect(console.error).toHaveBeenCalledWith('[Config] Unable to load config. Error: Loaded config is not an object');
+    expect(console.error).toHaveBeenCalled();
     expect(process.exit).toHaveBeenCalledWith(1);
 });
 
@@ -83,9 +83,7 @@ test('An error is thrown if the data has invalid server config', async () => {
 
     await FilesystemConfigLoader.loadConfig();
 
-    expect(console.error).toHaveBeenCalledWith(
-        '[Config] Unable to load config. Error: Loaded config section invalid: server'
-    );
+    expect(console.error).toHaveBeenCalled();
     expect(process.exit).toHaveBeenCalledWith(1);
 });
 
@@ -96,9 +94,7 @@ test('An error is thrown if the data has invalid moduleClient config', async () 
 
     await FilesystemConfigLoader.loadConfig();
 
-    expect(console.error).toHaveBeenCalledWith(
-        '[Config] Unable to load config. Error: Loaded config section invalid: moduleClient'
-    );
+    expect(console.error).toHaveBeenCalled();
     expect(process.exit).toHaveBeenCalledWith(1);
 });
 

--- a/back-end/config/loader/Filesystem.test.js
+++ b/back-end/config/loader/Filesystem.test.js
@@ -1,7 +1,9 @@
-const FilesystemConfigLoader = require('./Filesystem');
-const Config = require('../Config');
-
 let mockConfig;
+let Config;
+let FilesystemConfigLoader;
+
+const invalidObjects = [['undefined', undefined], ['null', null], ['a test string', 'test'], ['an empty array', []]];
+const invalidArrays = [['undefined', undefined], ['null', null], ['a test string', 'test'], ['an object', {}]];
 
 beforeEach(() => {
     console.log = jest.fn();
@@ -15,59 +17,64 @@ beforeEach(() => {
         server: {},
         moduleClient: {},
     };
+
+    Config = require('../Config');
+    FilesystemConfigLoader = require('./Filesystem');
 });
 
-test('An error is thrown if the data is not a valid object', async () => {
-    FilesystemConfigLoader.loadConfigFromFilesystem = jest.fn().mockReturnValue('test');
+test.each(invalidObjects)('An error is thrown if the config is %s', async (description, invalidObject) => {
+    FilesystemConfigLoader.loadConfigFromFilesystem = jest.fn().mockReturnValue(invalidObject);
 
     await FilesystemConfigLoader.loadConfig();
-    FilesystemConfigLoader.getConfig();
 
     expect(console.error).toHaveBeenCalledWith('[Config] Unable to load config. Error: Loaded config is not an object');
     expect(process.exit).toHaveBeenCalledWith(1);
 });
 
-test('An error is thrown if the data has invalid triggers', async () => {
-    mockConfig.triggers = undefined;
+test.each(invalidArrays)(
+    'Triggers config is converted to an empty array if it is %s',
+    async (description, invalidArray) => {
+        mockConfig.triggers = invalidArray;
 
-    FilesystemConfigLoader.loadConfigFromFilesystem = jest.fn().mockReturnValue(mockConfig);
+        FilesystemConfigLoader.loadConfigFromFilesystem = jest.fn().mockReturnValue(mockConfig);
 
-    await FilesystemConfigLoader.loadConfig();
-    FilesystemConfigLoader.getConfig();
+        await FilesystemConfigLoader.loadConfig();
 
-    expect(console.error).toHaveBeenCalledWith(
-        '[Config] Unable to load config. Error: Loaded config section invalid: triggers'
-    );
-    expect(process.exit).toHaveBeenCalledWith(1);
-});
+        expect(console.error).not.toHaveBeenCalled();
+        expect(process.exit).not.toHaveBeenCalled();
+        expect(mockConfig.triggers).toEqual([]);
+    }
+);
 
-test('An error is thrown if the data has invalid events', async () => {
-    mockConfig.events = new Object();
+test.each(invalidArrays)(
+    'Events config is converted to an empty array if it is %s',
+    async (description, invalidArray) => {
+        mockConfig.events = invalidArray;
 
-    FilesystemConfigLoader.loadConfigFromFilesystem = jest.fn().mockReturnValue(mockConfig);
+        FilesystemConfigLoader.loadConfigFromFilesystem = jest.fn().mockReturnValue(mockConfig);
 
-    await FilesystemConfigLoader.loadConfig();
-    FilesystemConfigLoader.getConfig();
+        await FilesystemConfigLoader.loadConfig();
 
-    expect(console.error).toHaveBeenCalledWith(
-        '[Config] Unable to load config. Error: Loaded config section invalid: events'
-    );
-    expect(process.exit).toHaveBeenCalledWith(1);
-});
+        expect(console.error).not.toHaveBeenCalled();
+        expect(process.exit).not.toHaveBeenCalled();
+        expect(mockConfig.events).toEqual([]);
+    }
+);
 
-test('An error is thrown if the data has invalid modules', async () => {
-    mockConfig.modules = 'test';
+test.each(invalidArrays)(
+    'Modules config is converted to an empty array if it is %s',
+    async (description, invalidArray) => {
+        mockConfig.modules = invalidArray;
 
-    FilesystemConfigLoader.loadConfigFromFilesystem = jest.fn().mockReturnValue(mockConfig);
+        FilesystemConfigLoader.loadConfigFromFilesystem = jest.fn().mockReturnValue(mockConfig);
 
-    await FilesystemConfigLoader.loadConfig();
-    FilesystemConfigLoader.getConfig();
+        await FilesystemConfigLoader.loadConfig();
 
-    expect(console.error).toHaveBeenCalledWith(
-        '[Config] Unable to load config. Error: Loaded config section invalid: modules'
-    );
-    expect(process.exit).toHaveBeenCalledWith(1);
-});
+        expect(console.error).not.toHaveBeenCalled();
+        expect(process.exit).not.toHaveBeenCalled();
+        expect(mockConfig.modules).toEqual([]);
+    }
+);
 
 test('An error is thrown if the data has invalid server config', async () => {
     mockConfig.server = [];
@@ -75,7 +82,6 @@ test('An error is thrown if the data has invalid server config', async () => {
     FilesystemConfigLoader.loadConfigFromFilesystem = jest.fn().mockReturnValue(mockConfig);
 
     await FilesystemConfigLoader.loadConfig();
-    FilesystemConfigLoader.getConfig();
 
     expect(console.error).toHaveBeenCalledWith(
         '[Config] Unable to load config. Error: Loaded config section invalid: server'
@@ -89,7 +95,6 @@ test('An error is thrown if the data has invalid moduleClient config', async () 
     FilesystemConfigLoader.loadConfigFromFilesystem = jest.fn().mockReturnValue(mockConfig);
 
     await FilesystemConfigLoader.loadConfig();
-    FilesystemConfigLoader.getConfig();
 
     expect(console.error).toHaveBeenCalledWith(
         '[Config] Unable to load config. Error: Loaded config section invalid: moduleClient'

--- a/back-end/config/loader/Firebase.js
+++ b/back-end/config/loader/Firebase.js
@@ -7,7 +7,11 @@ class Firebase extends AbstractConfigLoader {
         console.log('[Config] Loading config from Firebase...');
 
         try {
-            const config = await this.loadConfigFromFirebase();
+            const config = await FirebaseStorage.load('config');
+
+            config.triggers = config.triggers || [];
+            config.events = config.events || [];
+            config.modules = config.modules || [];
 
             this.validateConfig(config);
 
@@ -24,34 +28,6 @@ class Firebase extends AbstractConfigLoader {
             console.error('[Config] Unable to load config. ' + error.toString());
             process.exit(1);
         }
-    }
-
-    async loadConfigFromFirebase() {
-        return await FirebaseStorage.load('config').then(firebaseConfig => {
-            let config = {
-                triggers: [],
-                events: [],
-                modules: [],
-                server: {},
-                moduleClient: {},
-            };
-            firebaseConfig = firebaseConfig.toJSON();
-
-            /**
-             * Firebase always returns an object, even if we stored an array. To get back to
-             * the original data structure we check in the config stub above if we want an
-             * array or an object for each key, and if necessary convert the object.
-             */
-            Object.keys(firebaseConfig).forEach(key => {
-                if (Array.isArray(config[key])) {
-                    config[key] = Object.values(firebaseConfig[key]);
-                    return;
-                }
-                config[key] = firebaseConfig[key];
-            });
-
-            return config;
-        });
     }
 }
 

--- a/back-end/config/loader/Firebase.js
+++ b/back-end/config/loader/Firebase.js
@@ -7,12 +7,9 @@ class Firebase extends AbstractConfigLoader {
         console.log('[Config] Loading config from Firebase...');
 
         try {
-            const config = await FirebaseStorage.load('config');
+            const config = await this.loadConfigFromFirebase();
 
-            config.triggers = config.triggers || [];
-            config.events = config.events || [];
-            config.modules = config.modules || [];
-
+            this.setConfigDefaults(config);
             this.validateConfig(config);
 
             this.config = new Config(
@@ -28,6 +25,10 @@ class Firebase extends AbstractConfigLoader {
             console.error('[Config] Unable to load config. ' + error.toString());
             process.exit(1);
         }
+    }
+
+    async loadConfigFromFirebase() {
+        return await FirebaseStorage.load('config');
     }
 }
 

--- a/back-end/config/loader/Firebase.test.js
+++ b/back-end/config/loader/Firebase.test.js
@@ -36,7 +36,7 @@ test.each(invalidObjects)('An error is thrown if the config is %s', async (descr
     await FirebaseConfigLoader.loadConfig();
     FirebaseConfigLoader.getConfig();
 
-    expect(console.error).toHaveBeenCalledWith('[Config] Unable to load config. Error: Loaded config is not an object');
+    expect(console.error).toHaveBeenCalled();
     expect(process.exit).toHaveBeenCalledWith(1);
 });
 
@@ -48,7 +48,6 @@ test.each(invalidArrays)(
         FirebaseConfigLoader.loadConfigFromFirebase = jest.fn().mockReturnValue(mockConfig);
 
         await FirebaseConfigLoader.loadConfig();
-        FirebaseConfigLoader.getConfig();
 
         expect(console.error).not.toHaveBeenCalled();
         expect(process.exit).not.toHaveBeenCalled();
@@ -64,7 +63,6 @@ test.each(invalidArrays)(
         FirebaseConfigLoader.loadConfigFromFirebase = jest.fn().mockReturnValue(mockConfig);
 
         await FirebaseConfigLoader.loadConfig();
-        FirebaseConfigLoader.getConfig();
 
         expect(console.error).not.toHaveBeenCalled();
         expect(process.exit).not.toHaveBeenCalled();
@@ -80,7 +78,6 @@ test.each(invalidArrays)(
         FirebaseConfigLoader.loadConfigFromFirebase = jest.fn().mockReturnValue(mockConfig);
 
         await FirebaseConfigLoader.loadConfig();
-        FirebaseConfigLoader.getConfig();
 
         expect(console.error).not.toHaveBeenCalled();
         expect(process.exit).not.toHaveBeenCalled();
@@ -88,17 +85,25 @@ test.each(invalidArrays)(
     }
 );
 
+test.each(invalidObjects)('An error is thrown if server config is %s', async (description, invalidObject) => {
+    mockConfig.server = invalidObject;
+
+    FirebaseConfigLoader.loadConfigFromFirebase = jest.fn().mockReturnValue(mockConfig);
+
+    await FirebaseConfigLoader.loadConfig();
+
+    expect(console.error).toHaveBeenCalled();
+    expect(process.exit).toHaveBeenCalledWith(1);
+});
+
 test.each(invalidObjects)('An error is thrown if moduleClient config is %s', async (description, invalidObject) => {
     mockConfig.moduleClient = invalidObject;
 
     FirebaseConfigLoader.loadConfigFromFirebase = jest.fn().mockReturnValue(mockConfig);
 
     await FirebaseConfigLoader.loadConfig();
-    FirebaseConfigLoader.getConfig();
 
-    expect(console.error).toHaveBeenCalledWith(
-        '[Config] Unable to load config. Error: Loaded config section invalid: moduleClient'
-    );
+    expect(console.error).toHaveBeenCalled();
     expect(process.exit).toHaveBeenCalledWith(1);
 });
 

--- a/back-end/config/loader/Firebase.test.js
+++ b/back-end/config/loader/Firebase.test.js
@@ -2,6 +2,9 @@ let mockConfig;
 let FirebaseStorage;
 let FirebaseConfigLoader;
 
+const invalidObjects = [['undefined', undefined], ['null', null], ['a test string', 'test'], ['an empty array', []]];
+const invalidArrays = [['undefined', undefined], ['null', null], ['a test string', 'test'], ['an object', {}]];
+
 beforeAll(() => {
     process.env['FIREBASE_URL'] = 'test.firebaseio.com';
     process.env['FIREBASE_PRIVATE_KEY_FILE'] = 'tests/_data/firebase-private-key-file.json';
@@ -27,8 +30,8 @@ beforeEach(() => {
     FirebaseConfigLoader = require('../../config/loader/Firebase');
 });
 
-test('An error is thrown if the data is not a valid object', async () => {
-    FirebaseConfigLoader.loadConfigFromFirebase = jest.fn().mockReturnValue('test');
+test.each(invalidObjects)('An error is thrown if the config is %s', async (description, invalidObject) => {
+    FirebaseConfigLoader.loadConfigFromFirebase = jest.fn().mockReturnValue(invalidObject);
 
     await FirebaseConfigLoader.loadConfig();
     FirebaseConfigLoader.getConfig();
@@ -37,64 +40,56 @@ test('An error is thrown if the data is not a valid object', async () => {
     expect(process.exit).toHaveBeenCalledWith(1);
 });
 
-test('An error is thrown if the data has invalid triggers', async () => {
-    mockConfig.triggers = undefined;
+test.each(invalidArrays)(
+    'Triggers config is converted to an empty array if it is %s',
+    async (description, invalidArray) => {
+        mockConfig.triggers = invalidArray;
 
-    FirebaseConfigLoader.loadConfigFromFirebase = jest.fn().mockReturnValue(mockConfig);
+        FirebaseConfigLoader.loadConfigFromFirebase = jest.fn().mockReturnValue(mockConfig);
 
-    await FirebaseConfigLoader.loadConfig();
-    FirebaseConfigLoader.getConfig();
+        await FirebaseConfigLoader.loadConfig();
+        FirebaseConfigLoader.getConfig();
 
-    expect(console.error).toHaveBeenCalledWith(
-        '[Config] Unable to load config. Error: Loaded config section invalid: triggers'
-    );
-    expect(process.exit).toHaveBeenCalledWith(1);
-});
+        expect(console.error).not.toHaveBeenCalled();
+        expect(process.exit).not.toHaveBeenCalled();
+        expect(mockConfig.triggers).toEqual([]);
+    }
+);
 
-test('An error is thrown if the data has invalid events', async () => {
-    mockConfig.events = new Object();
+test.each(invalidArrays)(
+    'Events config is converted to an empty array if it is %s',
+    async (description, invalidArray) => {
+        mockConfig.events = invalidArray;
 
-    FirebaseConfigLoader.loadConfigFromFirebase = jest.fn().mockReturnValue(mockConfig);
+        FirebaseConfigLoader.loadConfigFromFirebase = jest.fn().mockReturnValue(mockConfig);
 
-    await FirebaseConfigLoader.loadConfig();
-    FirebaseConfigLoader.getConfig();
+        await FirebaseConfigLoader.loadConfig();
+        FirebaseConfigLoader.getConfig();
 
-    expect(console.error).toHaveBeenCalledWith(
-        '[Config] Unable to load config. Error: Loaded config section invalid: events'
-    );
-    expect(process.exit).toHaveBeenCalledWith(1);
-});
+        expect(console.error).not.toHaveBeenCalled();
+        expect(process.exit).not.toHaveBeenCalled();
+        expect(mockConfig.events).toEqual([]);
+    }
+);
 
-test('An error is thrown if the data has invalid modules', async () => {
-    mockConfig.modules = 'test';
+test.each(invalidArrays)(
+    'Modules config is converted to an empty array if it is %s',
+    async (description, invalidArray) => {
+        mockConfig.modules = invalidArray;
 
-    FirebaseConfigLoader.loadConfigFromFirebase = jest.fn().mockReturnValue(mockConfig);
+        FirebaseConfigLoader.loadConfigFromFirebase = jest.fn().mockReturnValue(mockConfig);
 
-    await FirebaseConfigLoader.loadConfig();
-    FirebaseConfigLoader.getConfig();
+        await FirebaseConfigLoader.loadConfig();
+        FirebaseConfigLoader.getConfig();
 
-    expect(console.error).toHaveBeenCalledWith(
-        '[Config] Unable to load config. Error: Loaded config section invalid: modules'
-    );
-    expect(process.exit).toHaveBeenCalledWith(1);
-});
+        expect(console.error).not.toHaveBeenCalled();
+        expect(process.exit).not.toHaveBeenCalled();
+        expect(mockConfig.modules).toEqual([]);
+    }
+);
 
-test('An error is thrown if the data has invalid server config', async () => {
-    mockConfig.server = [];
-
-    FirebaseConfigLoader.loadConfigFromFirebase = jest.fn().mockReturnValue(mockConfig);
-
-    await FirebaseConfigLoader.loadConfig();
-    FirebaseConfigLoader.getConfig();
-
-    expect(console.error).toHaveBeenCalledWith(
-        '[Config] Unable to load config. Error: Loaded config section invalid: server'
-    );
-    expect(process.exit).toHaveBeenCalledWith(1);
-});
-
-test('An error is thrown if the data has invalid moduleClient config', async () => {
-    mockConfig.moduleClient = [];
+test.each(invalidObjects)('An error is thrown if moduleClient config is %s', async (description, invalidObject) => {
+    mockConfig.moduleClient = invalidObject;
 
     FirebaseConfigLoader.loadConfigFromFirebase = jest.fn().mockReturnValue(mockConfig);
 
@@ -108,17 +103,9 @@ test('An error is thrown if the data has invalid moduleClient config', async () 
 });
 
 test('The Config object is valid if the data is correct', async () => {
-    let mockObject = {
-        toJSON: jest.fn(() => {
-            console.log('returning the mock config');
-            console.log(mockConfig);
-            return mockConfig;
-        }),
-    };
-
     FirebaseStorage.load = jest.fn().mockReturnValue(
         new Promise(resolve => {
-            resolve(mockObject);
+            resolve(mockConfig);
         })
     );
 

--- a/back-end/domain/status/persister/Firebase.js
+++ b/back-end/domain/status/persister/Firebase.js
@@ -23,7 +23,6 @@ class Firebase extends AbstractPersister {
 
         try {
             let data = await FirebaseStorage.load('statuses');
-            data = data.toJSON();
             if (data === null) {
                 console.log(`[FirebasePersister] No previous statuses in Firebase...`);
                 return;

--- a/back-end/module-client.js
+++ b/back-end/module-client.js
@@ -1,3 +1,9 @@
+try {
+    require('dotenv').config();
+} catch (error) {
+    // No dotenv package found...
+}
+
 (async () => {
     const ConfigLoader = require('./config/ConfigLoaderFactory').getLoader();
     await ConfigLoader.loadConfig();

--- a/back-end/module-client.js
+++ b/back-end/module-client.js
@@ -1,8 +1,4 @@
-try {
-    require('dotenv').config();
-} catch (error) {
-    // No dotenv package found...
-}
+require('dotenv').config();
 
 (async () => {
     const ConfigLoader = require('./config/ConfigLoaderFactory').getLoader();

--- a/back-end/server.js
+++ b/back-end/server.js
@@ -2,6 +2,12 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const http = require('http');
 
+try {
+    require('dotenv').config();
+} catch (e) {
+    // No dotenv package found...
+}
+
 (async () => {
     const ConfigLoader = require('./config/ConfigLoaderFactory').getLoader();
     await ConfigLoader.loadConfig();

--- a/back-end/server.js
+++ b/back-end/server.js
@@ -16,7 +16,7 @@ const http = require('http');
     const VersionChecker = require('./domain/cimonitor/VersionChecker');
     const router = require('./routes');
 
-    const Config = ConfigLoader.getConfig();
+    const Config = await ConfigLoader.getConfig();
 
     const app = express();
     app.use(bodyParser.json());

--- a/back-end/server.js
+++ b/back-end/server.js
@@ -16,7 +16,7 @@ const http = require('http');
     const VersionChecker = require('./domain/cimonitor/VersionChecker');
     const router = require('./routes');
 
-    const Config = await ConfigLoader.getConfig();
+    const Config = ConfigLoader.getConfig();
 
     const app = express();
     app.use(bodyParser.json());

--- a/back-end/server.js
+++ b/back-end/server.js
@@ -2,11 +2,7 @@ const express = require('express');
 const bodyParser = require('body-parser');
 const http = require('http');
 
-try {
-    require('dotenv').config();
-} catch (e) {
-    // No dotenv package found...
-}
+require('dotenv').config();
 
 (async () => {
     const ConfigLoader = require('./config/ConfigLoaderFactory').getLoader();

--- a/back-end/storage/Firebase.js
+++ b/back-end/storage/Firebase.js
@@ -23,11 +23,14 @@ class Firebase {
 
     async load(ref) {
         try {
-            return await this.database.ref(ref).once('value', function(data) {
-                return data;
-            }).then(data => {
-                return FirebaseDataParser.convertObjectArraysToArrays(data.toJSON());
-            });
+            return await this.database
+                .ref(ref)
+                .once('value', function(data) {
+                    return data;
+                })
+                .then(data => {
+                    return FirebaseDataParser.convertObjectArraysToArrays(data.toJSON());
+                });
         } catch (error) {
             console.error(`[Firebase] ${error}`);
         }

--- a/back-end/storage/Firebase.js
+++ b/back-end/storage/Firebase.js
@@ -1,4 +1,5 @@
 const FirebaseAdmin = require('firebase-admin');
+const FirebaseDataParser = require('./FirebaseDataParser');
 
 class Firebase {
     constructor() {
@@ -24,6 +25,8 @@ class Firebase {
         try {
             return await this.database.ref(ref).once('value', function(data) {
                 return data;
+            }).then(data => {
+                return FirebaseDataParser.convertObjectArraysToArrays(data.toJSON());
             });
         } catch (error) {
             console.error(`[Firebase] ${error}`);

--- a/back-end/storage/FirebaseDataParser.js
+++ b/back-end/storage/FirebaseDataParser.js
@@ -1,6 +1,6 @@
 class FirebaseDataParser {
     convertObjectArraysToArrays(data) {
-        if (typeof data !== 'object') {
+        if (data === null || typeof data !== 'object') {
             return data;
         }
 

--- a/back-end/storage/FirebaseDataParser.test.js
+++ b/back-end/storage/FirebaseDataParser.test.js
@@ -71,6 +71,11 @@ const data = [
             3: 'test',
         },
     },
+    {
+        in: null,
+        out: null
+    },
+
 ];
 
 test('Test should verify that firebase array objects are parsed to native arrays', () => {

--- a/back-end/storage/FirebaseDataParser.test.js
+++ b/back-end/storage/FirebaseDataParser.test.js
@@ -73,9 +73,8 @@ const data = [
     },
     {
         in: null,
-        out: null
+        out: null,
     },
-
 ];
 
 test('Test should verify that firebase array objects are parsed to native arrays', () => {

--- a/dev/.env.firebase
+++ b/dev/.env.firebase
@@ -1,0 +1,3 @@
+STORAGE=firebase
+FIREBASE_PRIVATE_KEY_FILE=config/serviceAccountKey.json
+FIREBASE_URL=https://cimonitor-dev.firebaseio.com/

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
         "browser-sync": "^2.26.3",
         "browser-sync-webpack-plugin": "2.0.1",
         "cypress": "^3.2.0",
-        "dotenv": "^8.0.0",
         "eslint": "^5.16.0",
         "eslint-config-prettier": "^3.3.0",
         "eslint-plugin-cypress": "^2.1.2",
@@ -44,6 +43,7 @@
     "dependencies": {
         "babel-cli": "^6.26.0",
         "body-parser": "^1.18.3",
+        "dotenv": "^8.0.0",
         "express": "^4.16.3",
         "firebase-admin": "^7.1.1",
         "gravatar": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "browser-sync": "^2.26.3",
         "browser-sync-webpack-plugin": "2.0.1",
         "cypress": "^3.2.0",
+        "dotenv": "^8.0.0",
         "eslint": "^5.16.0",
         "eslint-config-prettier": "^3.3.0",
         "eslint-plugin-cypress": "^2.1.2",

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -24,9 +24,8 @@ mix.copy('front-end/static/', 'dashboard/');
 if (!mix.inProduction()) {
     mix.webpackConfig({ devtool: `inline-source-map` });
 
-    const Config = require('./back-end/config/Config');
     mix.browserSync({
-        proxy: `localhost:${Config.getServerPort()}`,
+        proxy: `localhost:9999`,
         injectChanges: false,
         files: [`dashboard/**/*`],
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3344,6 +3344,11 @@ dotenv@^4.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
   integrity sha1-hk7xN5rO1Vzm+V3r7NzhefegzR0=
 
+dotenv@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.0.0.tgz#ed310c165b4e8a97bb745b0a9d99c31bda566440"
+  integrity sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==
+
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.6.1.tgz#b1a7a29c4abfd639585efaecce80d666b1e34125"


### PR DESCRIPTION
### What

This fixes the Firebase status loader with the help of the FirebaseDataParser class introduced by @RickvdStaaij in #133. This also removes the need for specific logic at the Firebase config loader because the Firebase storage layer already takes care of all translations.

### Why

The current implementation of loading states from Firebase is broken because only the config loader knows how to correctly parse the objects from Firebase back into arrays.
