### PR TITLE
Add ability to trigger events directly from the API

### DIFF
--- a/back-end/domain/module/AbstractModule.js
+++ b/back-end/domain/module/AbstractModule.js
@@ -12,6 +12,7 @@ class AbstractModule {
     }
 
     /**
+     * @param config
      * @param {Status} status
      */
     fireEvent(config, status) {

--- a/back-end/routes/event.js
+++ b/back-end/routes/event.js
@@ -1,0 +1,29 @@
+const app = (module.exports = require('express')());
+const EventTrigger = require('../domain/event/EventTrigger.js');
+const Config = require('../config/ConfigLoaderFactory')
+    .getLoader()
+    .getConfig();
+
+app.post('/', (request, response) => {
+    console.log('/event [POST]');
+
+    const eventName = request.body.event;
+
+    if (!eventName) {
+        return response.status(422).json({
+            message: `Missing required field "event".`,
+        });
+    }
+
+    if (Config.getEventByName(eventName)) {
+        EventTrigger.fireModulesForEvent(eventName, null);
+
+        return response.json({
+            message: 'Event has been triggered!',
+        });
+    }
+
+    return response.status(404).json({
+        message: `The given event name "${eventName}" is not found.`,
+    });
+});

--- a/back-end/routes/index.js
+++ b/back-end/routes/index.js
@@ -6,3 +6,4 @@ app.use('/webhook', require('./webhook'));
 app.use('/debug', require('./debug'));
 app.use('/contributors', require('./contributors'));
 app.use('/version', require('./version'));
+app.use('/event', require('./event.js'));

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,4 +1,11 @@
-# Status API
+# API
+
+- [Statuses](#statuses)
+- [Events](#events)
+
+## Statuses
+
+### POST /status
 
 @todo: Explain that you can manually push statuses to the `POST /status`. The API will let you know what's required or not.
 
@@ -22,6 +29,26 @@
 | `image`     | no        | An URL to an image representing the status                               |
 | `userImage` | no        | An URL to an image showing the user who triggered the status             |
 
+### DELETE /status/:status-key
+
 @todo: Explain that you can remove statues using `DELETE /status/:status-key`
 
+### GET /status/clear-all
+
 @todo: Explain that yo can remove all statuses using `GET /status/clear-all`
+
+## Events
+
+### POST /event
+
+You can directly trigger an event (configured in the configuration) via `POST /event`.
+
+```json
+{
+    "event": "celebrate-success"
+}
+```
+
+| key         | required? | description                                                              |
+| ----------- | --------- | ------------------------------------------------------------------------ |
+| `event`     | yes       | They configuration key that used for the event that should be triggered. |

--- a/docs/API.md
+++ b/docs/API.md
@@ -49,6 +49,6 @@ You can directly trigger an event (configured in the configuration) via `POST /e
 }
 ```
 
-| key         | required? | description                                                              |
-| ----------- | --------- | ------------------------------------------------------------------------ |
-| `event`     | yes       | They configuration key that used for the event that should be triggered. |
+| key         | required? | description                                                                |
+| ----------- | --------- | -------------------------------------------------------------------------- |
+| `event`     | yes       | The configuration key that is used for the event that should be triggered. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,7 +12,7 @@ pages:
         - Run as a service: setup/run-as-service.md
         - Run with Docker: setup/run-with-docker.md
         - Setup Raspberry: setup/Raspberry.md
-    - Status API: status-API.md
+    - CIMonitor API: API.md
     - Link a service:
         - GitLab: services/GitLab.md
         - Travis CI: services/Travis-CI.md

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -24,9 +24,8 @@ mix.copy('front-end/static/', 'dashboard/');
 if (!mix.inProduction()) {
     mix.webpackConfig({ devtool: `inline-source-map` });
 
-    const Config = require('./back-end/config/Config');
     mix.browserSync({
-        proxy: `localhost:${Config.getServerPort()}`,
+        proxy: `localhost:9999`,
         injectChanges: false,
         files: [`dashboard/**/*`],
     });


### PR DESCRIPTION
### What

This PR adds the ability to trigger configured events directly from the API.

### Why

If you want to trigger an event, you now had to push a status that fitted the event you want to trigger. This PR exposes an endpoint that allows you to directly trigger an event instead.

### To do

- [x] Add documentation on `POST /event`
