### PR TITLE
Use date strings for internal statuses so Firebase can save them

### DIFF
--- a/back-end/domain/status/StatusFactory.js
+++ b/back-end/domain/status/StatusFactory.js
@@ -1,4 +1,5 @@
 const validate = require('validate.js');
+const moment = require('moment');
 
 const Events = require('../Events');
 const Status = require('./Status');
@@ -99,7 +100,10 @@ class StatusFactory {
         return validate
             .async(data, this.getStatusConstraints())
             .then(data => {
-                data = { ...data, time: new Date() };
+                data = {
+                    ...data,
+                    time: moment().format(),
+                };
                 const newStatus = new Status(data);
 
                 Events.push(Events.event.newStatus, newStatus);

--- a/back-end/domain/status/StatusManager.js
+++ b/back-end/domain/status/StatusManager.js
@@ -1,3 +1,5 @@
+const moment = require('moment');
+
 const Events = require('../Events');
 const EventTrigger = require('../event/EventTrigger');
 
@@ -46,7 +48,7 @@ class StatusManager {
                 // Get raw data only
                 .map(status => status.getRawData())
                 // Newest updates first
-                .sort((statusA, statusB) => statusA.time < statusB.time)
+                .sort((statusA, statusB) => moment(statusA.time).isBefore(statusB.time))
         );
     }
 


### PR DESCRIPTION
### What

- Use date strings for internal statuses so Firebase can save them
- Fixes https://github.com/CIMonitor/CIMonitor/issues/139

### Why

Why use dates, when you already have moment in your project? Just save the strings, and make them moment objects when you need them.
