### PR TITLE
Fix path to saved-statuses.json in docs

### DIFF
--- a/docs/setup/run-with-docker.md
+++ b/docs/setup/run-with-docker.md
@@ -17,7 +17,7 @@ Open your terminal in a folder with a `config.json` file and optionally a `saved
 docker run -ti \
     -p 9999:9999 \
     -v $PWD/config.json:/opt/CIMonitor/config/config.json \
-    -v $PWD/saved-statuses.json:/opt/CIMonitor/config/saved-statuses.json \
+    -v $PWD/saved-statuses.json:/opt/CIMonitor/back-end/config/saved-statuses.json \
     cimonitor/server:latest
 ```
 
@@ -45,7 +45,7 @@ the latest version of CIMonitor on a Raspberry pi 3 will look like the following
 docker run -ti \
     -p 9999:9999 \
     -v $PWD/config.json:/opt/CIMonitor/config/config.json \
-    -v $PWD/saved-statuses.json:/opt/CIMonitor/config/saved-statuses.json \
+    -v $PWD/saved-statuses.json:/opt/CIMonitor/back-end/config/saved-statuses.json \
     cimonitor/server:latest-arm64
 ```
 


### PR DESCRIPTION
### What

While trying to run the docker container I noticed the path of the `saved-statuses.json` in the documentation is incorrect, this PR should fix that.

### Why

Because I <3 documentation that is correct.
