### PR TITLE
Fix saved-statuses.json path

### DIFF
--- a/back-end/domain/status/persister/Filesystem.js
+++ b/back-end/domain/status/persister/Filesystem.js
@@ -10,7 +10,7 @@ class Filesystem extends AbstractPersister {
         super();
 
         const filename = `saved-statuses.json`;
-        const logPath = path.resolve(`${__dirname}/../../../config/`);
+        const logPath = path.resolve(`${__dirname}/../../../../config/`);
 
         this.statusesFile = `${logPath}/${filename}`;
     }


### PR DESCRIPTION
### What

Currently the saved-statuses.json file is saved in `back-end/config` instead of the `config`-directory because of relative path madness.

### Why

According to #144 this should be the expected behavior.
