### PR TITLE
Only toggle the stages on click, not on hover

### DIFF
--- a/front-end/components/Status/JobsAndStages/jobs-and-stages.vue
+++ b/front-end/components/Status/JobsAndStages/jobs-and-stages.vue
@@ -1,12 +1,12 @@
 <template>
-    <div class="detail-jobs-and-stages" @mouseleave="clearSelectedStage">
+    <div class="detail-jobs-and-stages">
         <div class="detail-stages" v-if="stages.length > 0">
             <div
                 class="detail-stage"
                 :class="getStageClasses(stage)"
                 v-for="stage in stages"
                 :key="stage"
-                @mouseenter="selectStage(stage)"
+                @click="toggleStage(stage)"
             >
                 {{ stage }}
             </div>
@@ -64,10 +64,11 @@ export default {
 
             return 'pending';
         },
-        clearSelectedStage() {
-            this.selectedStage = null;
-        },
-        selectStage(stage) {
+        toggleStage(stage) {
+            if (this.selectedStage === stage) {
+                return (this.selectedStage = null);
+            }
+
             this.selectedStage = stage;
         },
     },
@@ -162,6 +163,7 @@ export default {
     margin: 5px 0
     min-width: 0
     flex-shrink: 1
+    cursor: pointer
 
     &:first-child
         margin-left: 5px


### PR DESCRIPTION
### What

Only toggle the stages on click, not on hover

### Why

The dashboard was very chaotic whilst moving the mouse over the screen. Constantly stages would open and close on hover, giving an unpleasant UX. With this PR this behavior is changed to on-click, so you get a much smoother experience.
