### PR TITLE
Make sure only new processes are created

### DIFF
--- a/backend/parser/github/job.ts
+++ b/backend/parser/github/job.ts
@@ -9,7 +9,7 @@ class GitHubJobParser {
     parse(job: GitHubWorkflowJob): Status | null {
         const statuses = StatusManager.getStatuses();
 
-        const processId = `run-${job.workflow_job.run_id}`;
+        const processId = job.workflow_job.run_id;
 
         const targetStatus = statuses.find((status) => status.processes.find((process) => process.id === processId));
 

--- a/backend/parser/github/run.ts
+++ b/backend/parser/github/run.ts
@@ -22,9 +22,11 @@ class GitHubRunParser {
 
         let processes = status.processes;
 
-        const processId = `run-${run.workflow_run.id}`;
+        const processId = run.workflow_run.id;
 
         if (!processes.find((process) => process.id === processId)) {
+            // TODO: if process ID is smaller than the latest process ID, return null
+
             processes.push({
                 id: processId,
                 title: run.workflow_run.head_commit.message,

--- a/backend/parser/github/run.ts
+++ b/backend/parser/github/run.ts
@@ -1,3 +1,4 @@
+import { isOldProcess } from 'backend/status/helper';
 import StatusManager from 'backend/status/manager';
 import { GitHubWorkflowRun } from 'types/github';
 import Status from 'types/status';
@@ -5,7 +6,7 @@ import Status from 'types/status';
 import { getStateFromStatus } from './helper';
 
 class GitHubRunParser {
-    parse(id: string, run: GitHubWorkflowRun): Status {
+    parse(id: string, run: GitHubWorkflowRun): Status | null {
         let status = StatusManager.getStatus(id);
 
         if (!status) {
@@ -25,7 +26,9 @@ class GitHubRunParser {
         const processId = run.workflow_run.id;
 
         if (!processes.find((process) => process.id === processId)) {
-            // TODO: if process ID is smaller than the latest process ID, return null
+            if (isOldProcess(status, processId)) {
+                return null;
+            }
 
             processes.push({
                 id: processId,

--- a/backend/parser/gitlab/build.ts
+++ b/backend/parser/gitlab/build.ts
@@ -1,4 +1,5 @@
 import Slugify from 'backend/parser/slug';
+import { isOldProcess } from 'backend/status/helper';
 import StatusManager from 'backend/status/manager';
 import { GitLabBuild } from 'types/gitlab';
 import Status, { Process, Stage, Step, StepState } from 'types/status';
@@ -18,7 +19,9 @@ class GitLabBuildParser {
         const processId = build.pipeline_id;
 
         if (!processes.find((process) => process.id === processId)) {
-            // TODO: if process ID is smaller than the latest process ID, return null
+            if (isOldProcess(status, processId)) {
+                return null;
+            }
 
             processes.push({
                 id: processId,

--- a/backend/parser/gitlab/build.ts
+++ b/backend/parser/gitlab/build.ts
@@ -15,9 +15,11 @@ class GitLabBuildParser {
 
         const processes: Process[] = status.processes || [];
 
-        const processId = `pipeline-${build.pipeline_id}`;
+        const processId = build.pipeline_id;
 
         if (!processes.find((process) => process.id === processId)) {
+            // TODO: if process ID is smaller than the latest process ID, return null
+
             processes.push({
                 id: processId,
                 title: build.commit.message.split('\n\n')[0],

--- a/backend/parser/gitlab/pipeline.ts
+++ b/backend/parser/gitlab/pipeline.ts
@@ -1,4 +1,5 @@
 import Slugify from 'backend/parser/slug';
+import { isOldProcess } from 'backend/status/helper';
 import StatusManager from 'backend/status/manager';
 import { GitLabPipeline } from 'types/gitlab';
 import Status, { Process, Stage } from 'types/status';
@@ -6,7 +7,7 @@ import Status, { Process, Stage } from 'types/status';
 import { statusToState } from './helper';
 
 class GitLabPipelineParser {
-    parse(id: string, pipeline: GitLabPipeline): Status {
+    parse(id: string, pipeline: GitLabPipeline): Status | null {
         const status = this.getStatus(id, pipeline);
 
         let processes: Process[] = status.processes || [];
@@ -14,7 +15,9 @@ class GitLabPipelineParser {
         const processId = pipeline.object_attributes.id;
 
         if (!processes.find((process) => process.id === processId)) {
-            // TODO: if process ID is smaller than the latest process ID, return null
+            if (isOldProcess(status, processId)) {
+                return null;
+            }
 
             processes.push({
                 id: processId,

--- a/backend/parser/gitlab/pipeline.ts
+++ b/backend/parser/gitlab/pipeline.ts
@@ -11,9 +11,11 @@ class GitLabPipelineParser {
 
         let processes: Process[] = status.processes || [];
 
-        const processId = `pipeline-${pipeline.object_attributes.id}`;
+        const processId = pipeline.object_attributes.id;
 
         if (!processes.find((process) => process.id === processId)) {
+            // TODO: if process ID is smaller than the latest process ID, return null
+
             processes.push({
                 id: processId,
                 title: pipeline.commit.title,

--- a/backend/parser/readthedocs.ts
+++ b/backend/parser/readthedocs.ts
@@ -1,4 +1,5 @@
 import Slugify from 'backend/parser/slug';
+import { isOldProcess } from 'backend/status/helper';
 import StatusManager from 'backend/status/manager';
 import ReadTheDocsBuild from 'types/readthedocs';
 import Status, { Process, State, StepState } from 'types/status';
@@ -28,7 +29,7 @@ class ReadTheDocsParser {
         return 'running';
     }
 
-    parseBuild(build: ReadTheDocsBuild): Status {
+    parseBuild(build: ReadTheDocsBuild): Status | null {
         console.log('[parser/readthedocs] Parsing build...');
 
         const statusId = `readthedocs-${build.slug}-${Slugify(build.version)}`;
@@ -52,7 +53,9 @@ class ReadTheDocsParser {
         const processId = parseInt(build.build);
 
         if (!processes.find((process) => process.id === processId)) {
-            // TODO: if process ID is smaller than the latest process ID, return null
+            if (isOldProcess(status, processId)) {
+                return null;
+            }
 
             processes.push({
                 id: processId,

--- a/backend/parser/readthedocs.ts
+++ b/backend/parser/readthedocs.ts
@@ -49,9 +49,11 @@ class ReadTheDocsParser {
 
         let processes: Process[] = status.processes || [];
 
-        const processId = `build-${build.build}`;
+        const processId = parseInt(build.build);
 
         if (!processes.find((process) => process.id === processId)) {
+            // TODO: if process ID is smaller than the latest process ID, return null
+
             processes.push({
                 id: processId,
                 title: `Build ${build.build}`,

--- a/backend/status/helper.ts
+++ b/backend/status/helper.ts
@@ -15,10 +15,6 @@ export const getExpiredStatuses = (statuses: Status[]): Status[] =>
 export const getStuckStatuses = (statuses: Status[]): Status[] =>
     statuses.filter((status) => {
         for (let process of status.processes) {
-            if (process.state === 'warning' && isExpired(process.time, statusesTimeout)) {
-                return true;
-            }
-
             for (let stage of process.stages) {
                 if (stage.state === 'running' && isExpired(stage.time, statusesTimeout)) {
                     return true;
@@ -29,6 +25,14 @@ export const getStuckStatuses = (statuses: Status[]): Status[] =>
                         return true;
                     }
                 }
+            }
+
+            if (
+                process.state === 'warning' &&
+                isExpired(process.time, statusesTimeout) &&
+                !process.stages.find((stage) => stage.state === 'pending')
+            ) {
+                return true;
             }
         }
 
@@ -93,6 +97,16 @@ const determineStatusState = (processes: Process[]): State => {
     }
 
     return 'info';
+};
+
+export const isOldProcess = (status: Status, processId: number): boolean => {
+    if (status.processes.length === 0) {
+        return false;
+    }
+
+    const latestProcessId = status.processes[0].id;
+
+    return processId < latestProcessId;
 };
 
 const determineTimeoutProcessState = (stages: Stage[]): State => {

--- a/backend/status/helper.ts
+++ b/backend/status/helper.ts
@@ -30,6 +30,7 @@ export const getStuckStatuses = (statuses: Status[]): Status[] =>
             if (
                 process.state === 'warning' &&
                 isExpired(process.time, statusesTimeout) &&
+                // when there is a pending stage, the process is not stuck running
                 !process.stages.find((stage) => stage.state === 'pending')
             ) {
                 return true;

--- a/cypress/fixtures/github/push-failed/2.json
+++ b/cypress/fixtures/github/push-failed/2.json
@@ -1,18 +1,8 @@
 {
     "headers": {
-        "host": "86.88.15.154:3030",
         "user-agent": "GitHub-Hookshot/fdc2c31",
-        "content-length": "19657",
-        "accept": "*/*",
-        "x-github-delivery": "c181d630-a4aa-11ec-8baf-8fb136f5ee42",
         "x-github-event": "workflow_run",
-        "x-github-hook-id": "346531167",
-        "x-github-hook-installation-target-id": "56302138",
-        "x-github-hook-installation-target-type": "repository",
-        "x-hub-signature": "sha1=6ee7b3d4787eb9ecfd14c5688d5bec7888d9116a",
-        "x-hub-signature-256": "sha256=7fc894ad83361bbfc54d85a8c5e3ee02542a0bdd07b573b67cbe2841f2ea80a7",
-        "content-type": "application/json",
-        "connection": "close"
+        "content-type": "application/json"
     },
     "body": {
         "action": "requested",

--- a/cypress/fixtures/github/push/10.json
+++ b/cypress/fixtures/github/push/10.json
@@ -18,8 +18,8 @@
         "action": "in_progress",
         "workflow_job": {
             "id": 5558621403,
-            "run_id": 1988417362,
-            "run_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362",
+            "run_id": 1989460246,
+            "run_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246",
             "run_attempt": 1,
             "node_id": "CR_kwDOA1saOs8AAAABS1HU2w",
             "head_sha": "46b2179d2bc0a474e4511ece471792d6451c54b9",

--- a/cypress/fixtures/github/push/12.json
+++ b/cypress/fixtures/github/push/12.json
@@ -18,8 +18,8 @@
         "action": "completed",
         "workflow_job": {
             "id": 5558621403,
-            "run_id": 1988417362,
-            "run_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362",
+            "run_id": 1989460246,
+            "run_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246",
             "run_attempt": 1,
             "node_id": "CR_kwDOA1saOs8AAAABS1HU2w",
             "head_sha": "46b2179d2bc0a474e4511ece471792d6451c54b9",

--- a/cypress/fixtures/github/push/14.json
+++ b/cypress/fixtures/github/push/14.json
@@ -17,7 +17,7 @@
     "body": {
         "action": "completed",
         "workflow_run": {
-            "id": 1988417362,
+            "id": 1989460246,
             "name": "Build the CIMonitor v4 container",
             "node_id": "WFR_kwLOA1saOs52hNdS",
             "head_branch": "release/4",
@@ -29,8 +29,8 @@
             "workflow_id": 21158664,
             "check_suite_id": 5670635451,
             "check_suite_node_id": "CS_kwDOA1saOs8AAAABUf8Huw",
-            "url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362",
-            "html_url": "https://github.com/CIMonitor/CIMonitor/actions/runs/1988417362",
+            "url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246",
+            "html_url": "https://github.com/CIMonitor/CIMonitor/actions/runs/1989460246",
             "pull_requests": [],
             "created_at": "2022-03-15T18:00:15Z",
             "updated_at": "2022-03-15T18:02:14Z",
@@ -76,12 +76,12 @@
                 "type": "User",
                 "site_admin": false
             },
-            "jobs_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362/jobs",
-            "logs_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362/logs",
+            "jobs_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246/jobs",
+            "logs_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246/logs",
             "check_suite_url": "https://api.github.com/repos/CIMonitor/CIMonitor/check-suites/5670635451",
-            "artifacts_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362/artifacts",
-            "cancel_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362/cancel",
-            "rerun_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362/rerun",
+            "artifacts_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246/artifacts",
+            "cancel_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246/cancel",
+            "rerun_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246/rerun",
             "previous_attempt_url": null,
             "workflow_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/workflows/21158664",
             "head_commit": {

--- a/cypress/fixtures/github/push/2.json
+++ b/cypress/fixtures/github/push/2.json
@@ -17,7 +17,7 @@
     "body": {
         "action": "requested",
         "workflow_run": {
-            "id": 1988417362,
+            "id": 1989460246,
             "name": "Build the CIMonitor v4 container",
             "node_id": "WFR_kwLOA1saOs52hNdS",
             "head_branch": "release/4",
@@ -29,8 +29,8 @@
             "workflow_id": 21158664,
             "check_suite_id": 5670635451,
             "check_suite_node_id": "CS_kwDOA1saOs8AAAABUf8Huw",
-            "url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362",
-            "html_url": "https://github.com/CIMonitor/CIMonitor/actions/runs/1988417362",
+            "url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246",
+            "html_url": "https://github.com/CIMonitor/CIMonitor/actions/runs/1989460246",
             "pull_requests": [],
             "created_at": "2022-03-15T18:00:15Z",
             "updated_at": "2022-03-15T18:00:15Z",
@@ -76,12 +76,12 @@
                 "type": "User",
                 "site_admin": false
             },
-            "jobs_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362/jobs",
-            "logs_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362/logs",
+            "jobs_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246/jobs",
+            "logs_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246/logs",
             "check_suite_url": "https://api.github.com/repos/CIMonitor/CIMonitor/check-suites/5670635451",
-            "artifacts_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362/artifacts",
-            "cancel_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362/cancel",
-            "rerun_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362/rerun",
+            "artifacts_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246/artifacts",
+            "cancel_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246/cancel",
+            "rerun_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246/rerun",
             "previous_attempt_url": null,
             "workflow_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/workflows/21158664",
             "head_commit": {

--- a/cypress/fixtures/github/push/3.json
+++ b/cypress/fixtures/github/push/3.json
@@ -18,8 +18,8 @@
         "action": "queued",
         "workflow_job": {
             "id": 5558609340,
-            "run_id": 1988417362,
-            "run_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362",
+            "run_id": 1989460246,
+            "run_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246",
             "run_attempt": 1,
             "node_id": "CR_kwDOA1saOs8AAAABS1GlvA",
             "head_sha": "46b2179d2bc0a474e4511ece471792d6451c54b9",

--- a/cypress/fixtures/github/push/5.json
+++ b/cypress/fixtures/github/push/5.json
@@ -18,8 +18,8 @@
         "action": "in_progress",
         "workflow_job": {
             "id": 5558609340,
-            "run_id": 1988417362,
-            "run_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362",
+            "run_id": 1989460246,
+            "run_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246",
             "run_attempt": 1,
             "node_id": "CR_kwDOA1saOs8AAAABS1GlvA",
             "head_sha": "46b2179d2bc0a474e4511ece471792d6451c54b9",

--- a/cypress/fixtures/github/push/7.json
+++ b/cypress/fixtures/github/push/7.json
@@ -18,8 +18,8 @@
         "action": "completed",
         "workflow_job": {
             "id": 5558609340,
-            "run_id": 1988417362,
-            "run_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362",
+            "run_id": 1989460246,
+            "run_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246",
             "run_attempt": 1,
             "node_id": "CR_kwDOA1saOs8AAAABS1GlvA",
             "head_sha": "46b2179d2bc0a474e4511ece471792d6451c54b9",

--- a/cypress/fixtures/github/push/9.json
+++ b/cypress/fixtures/github/push/9.json
@@ -18,8 +18,8 @@
         "action": "queued",
         "workflow_job": {
             "id": 5558621403,
-            "run_id": 1988417362,
-            "run_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1988417362",
+            "run_id": 1989460246,
+            "run_url": "https://api.github.com/repos/CIMonitor/CIMonitor/actions/runs/1989460246",
             "run_attempt": 1,
             "node_id": "CR_kwDOA1saOs8AAAABS1HU2w",
             "head_sha": "46b2179d2bc0a474e4511ece471792d6451c54b9",

--- a/cypress/fixtures/readthedocs/build-success/1.json
+++ b/cypress/fixtures/readthedocs/build-success/1.json
@@ -11,9 +11,9 @@
         "slug": "cimonitor",
         "version": "latest",
         "commit": "",
-        "build": "16398754",
+        "build": "16398756",
         "start_date": "2022-03-17T19:36:36",
-        "build_url": "https://readthedocs.org/projects/cimonitor/builds/16398754/",
+        "build_url": "https://readthedocs.org/projects/cimonitor/builds/16398756/",
         "docs_url": "https://cimonitor.readthedocs.io/en/latest/"
     }
 }

--- a/cypress/fixtures/readthedocs/build-success/2.json
+++ b/cypress/fixtures/readthedocs/build-success/2.json
@@ -11,9 +11,9 @@
         "slug": "cimonitor",
         "version": "latest",
         "commit": "0db32cbc81d15d1e69aabbff4152c3ef28260077",
-        "build": "16398754",
+        "build": "16398756",
         "start_date": "2022-03-17T19:36:36",
-        "build_url": "https://readthedocs.org/projects/cimonitor/builds/16398754/",
+        "build_url": "https://readthedocs.org/projects/cimonitor/builds/16398756/",
         "docs_url": "https://cimonitor.readthedocs.io/en/latest/"
     }
 }

--- a/types/status.ts
+++ b/types/status.ts
@@ -27,7 +27,7 @@ export type Stage = {
 };
 
 export type Process = {
-    id: string;
+    id: number;
     title: string;
     state: State;
     stages: Stage[];


### PR DESCRIPTION
# What

Make sure only new processes are created.

## Why

Some times, when an already completed and thus removed process gets a delayed callback, the process is re-created as if it was new. This will mess with the actually latest process, that should always remain visible.

## To do

- [x] Change process id from `string` to `int`
- [x] Actually don't create the processes if they're older than the latest
