### PR TITLE
Add user field to statuses and add option to hide user avatars

### DIFF
--- a/backend/parser/github/pull-request.ts
+++ b/backend/parser/github/pull-request.ts
@@ -20,9 +20,11 @@ class GitHubPullRequestParser {
 
         return {
             ...status,
+            username: pullRequest.sender.login,
+            userUrl: pullRequest.sender.html_url,
             userImage: pullRequest.sender.avatar_url,
             projectImage: pullRequest.organization.avatar_url,
-            source_url: pullRequest.repository.html_url,
+            sourceUrl: pullRequest.repository.html_url,
             mergeTitle: pullRequest.pull_request.title,
             mergeUrl: pullRequest.pull_request.html_url,
             time: new Date().toUTCString(),

--- a/backend/parser/github/push.ts
+++ b/backend/parser/github/push.ts
@@ -31,9 +31,11 @@ class GitHubPushParser {
 
         return {
             ...status,
+            username: push.sender.login,
+            userUrl: push.sender.html_url,
             userImage: push.sender.avatar_url,
             projectImage: push.organization.avatar_url,
-            source_url: push.repository.html_url,
+            sourceUrl: push.repository.html_url,
             time: new Date().toUTCString(),
         };
     }

--- a/backend/parser/github/run.ts
+++ b/backend/parser/github/run.ts
@@ -52,9 +52,11 @@ class GitHubRunParser {
 
         return {
             ...status,
+            username: run.sender.login,
+            userUrl: run.sender.html_url,
             userImage: run.sender.avatar_url,
             projectImage: run.organization.avatar_url,
-            source_url: run.repository.html_url,
+            sourceUrl: run.repository.html_url,
             processes,
             time: new Date().toUTCString(),
         };

--- a/backend/parser/gitlab/build.ts
+++ b/backend/parser/gitlab/build.ts
@@ -67,8 +67,10 @@ class GitLabBuildParser {
             }
         }
 
+        status.username = build.user.name || build.user.username;
+        status.userUrl = build.commit.author_url;
         status.userImage = build.user.avatar_url;
-        status.source_url = build.repository.homepage;
+        status.sourceUrl = build.repository.homepage;
 
         return status;
     }

--- a/backend/parser/gitlab/deployment.ts
+++ b/backend/parser/gitlab/deployment.ts
@@ -30,8 +30,10 @@ class GitLabDeploymentParser {
         return {
             ...status,
             projectImage: deployment.project.avatar_url,
+            username: deployment.user.name || deployment.user.username,
             userImage: deployment.user.avatar_url,
-            source_url: deployment.project.git_http_url,
+            userUrl: deployment.user_url,
+            sourceUrl: deployment.project.git_http_url,
             tag: deployment.environment,
             time: new Date().toUTCString(),
         };

--- a/backend/parser/gitlab/merge-request.ts
+++ b/backend/parser/gitlab/merge-request.ts
@@ -25,8 +25,9 @@ class GitLabMergeRequestParser {
         return {
             ...status,
             projectImage: mergeRequest.project.avatar_url,
+            username: mergeRequest.user.name || mergeRequest.user.username,
             userImage: mergeRequest.user.avatar_url,
-            source_url: mergeRequest.project.git_http_url,
+            sourceUrl: mergeRequest.project.git_http_url,
             mergeTitle: mergeRequest.object_attributes.title,
             mergeUrl: mergeRequest.object_attributes.url,
             time: new Date().toUTCString(),

--- a/backend/parser/gitlab/pipeline.ts
+++ b/backend/parser/gitlab/pipeline.ts
@@ -65,9 +65,10 @@ class GitLabPipelineParser {
             }
         }
 
+        status.username = pipeline.user.name || pipeline.user.username;
         status.userImage = pipeline.user.avatar_url;
         status.projectImage = pipeline.project.avatar_url;
-        status.source_url = pipeline.project.git_http_url;
+        status.sourceUrl = pipeline.project.git_http_url;
 
         return status;
     }

--- a/backend/parser/readthedocs.ts
+++ b/backend/parser/readthedocs.ts
@@ -78,7 +78,7 @@ class ReadTheDocsParser {
             ...status,
             processes,
             url: build.docs_url,
-            source_url: build.build_url,
+            sourceUrl: build.build_url,
             state: this.determineState(processes),
             time: new Date().toUTCString(),
         };

--- a/frontend/App/SettingsPanel/Customization/Customization.tsx
+++ b/frontend/App/SettingsPanel/Customization/Customization.tsx
@@ -7,12 +7,13 @@ import { Content } from '/frontend/App/SettingsPanel/SettingsPanel.style';
 import Icon from '/frontend/components/Icon';
 import Modifier from '/frontend/components/Modifier';
 import Toggle from '/frontend/components/Toggle';
-import { setSizeModifier, toggleShowCompleted } from '/frontend/store/settings/actions';
-import { getSizeModifier, isShowingCompleted } from '/frontend/store/settings/selectors';
+import { setSizeModifier, toggleShowCompleted, toggleShowUserAvatars } from '/frontend/store/settings/actions';
+import { getSizeModifier, isShowingCompleted, isShowingUserAvatars } from '/frontend/store/settings/selectors';
 
 const Customization = (): ReactElement => {
     const showCompleted = useSelector(isShowingCompleted);
     const sizeModifier = useSelector(getSizeModifier);
+    const showUserAvatars = useSelector(isShowingUserAvatars);
     const dispatch = useDispatch();
 
     const server = <Icon icon="warning" state="warning" title="Server setting" />;
@@ -32,6 +33,15 @@ const Customization = (): ReactElement => {
                 </About>
                 <Tool>
                     <Toggle onToggle={() => dispatch(toggleShowCompleted())} enabled={showCompleted} />
+                </Tool>
+            </Setting>
+            <Setting>
+                <About>
+                    <Title>Show user avatars</Title>
+                    <Description>Do you want to see the user avatar images?</Description>
+                </About>
+                <Tool>
+                    <Toggle onToggle={() => dispatch(toggleShowUserAvatars())} enabled={showUserAvatars} />
                 </Tool>
             </Setting>
             <Setting>

--- a/frontend/App/Statuses/Status/Status.tsx
+++ b/frontend/App/Statuses/Status/Status.tsx
@@ -9,6 +9,7 @@ import Process from './Process';
 import ProjectImage from './ProjectImage';
 import Source from './Source';
 import TimePassed from './TimePassed';
+import User from './User';
 
 import Status from '/types/status';
 
@@ -30,7 +31,7 @@ const Statuses = ({ status }: Props): ReactElement => (
             <Details>
                 <Project>{status.project}</Project>
                 <Boxes>
-                    <Source type={status.source} url={status.source_url} />
+                    <Source type={status.source} url={status.sourceUrl} />
                     {status.branch && (
                         <Box>
                             <Icon icon="commit" /> {status.branch}
@@ -47,6 +48,7 @@ const Statuses = ({ status }: Props): ReactElement => (
                             <Icon icon="launch" /> {pettyUrl(status.url)}
                         </LinkBox>
                     )}
+                    <User username={status.username} url={status.userUrl} />
                     <Box>
                         <Icon icon="schedule" /> <TimePassed since={status.time} />
                     </Box>

--- a/frontend/App/Statuses/Status/Status.tsx
+++ b/frontend/App/Statuses/Status/Status.tsx
@@ -1,8 +1,10 @@
 import { ReactElement } from 'react';
+import { useSelector } from 'react-redux';
 
 import { Body, Box, Boxes, Container, Details, LinkBox, Project, UserImage } from './Status.style';
 
 import Icon from '/frontend/components/Icon';
+import { isShowingUserAvatars } from '/frontend/store/settings/selectors';
 
 import Merge from './Merge';
 import Process from './Process';
@@ -24,44 +26,48 @@ const pettyUrl = (url: string) =>
         // strip / on the end
         .replace(/\/$/, '');
 
-const Statuses = ({ status }: Props): ReactElement => (
-    <Container key={status.id} state={status.state}>
-        <Body>
-            {status.projectImage && <ProjectImage url={status.projectImage} alt="Project image" />}
-            <Details>
-                <Project>{status.project}</Project>
-                <Boxes>
-                    <Source type={status.source} url={status.sourceUrl} />
-                    {status.branch && (
+const Statuses = ({ status }: Props): ReactElement => {
+    const showUserAvatar = useSelector(isShowingUserAvatars);
+
+    return (
+        <Container key={status.id} state={status.state}>
+            <Body>
+                {status.projectImage && <ProjectImage url={status.projectImage} alt="Project image" />}
+                <Details>
+                    <Project>{status.project}</Project>
+                    <Boxes>
+                        <Source type={status.source} url={status.sourceUrl} />
+                        {status.branch && (
+                            <Box>
+                                <Icon icon="commit" /> {status.branch}
+                            </Box>
+                        )}
+                        {status.tag && (
+                            <Box>
+                                <Icon icon="bookmark_border" /> {status.tag}
+                            </Box>
+                        )}
+                        <Merge title={status.mergeTitle} url={status.mergeUrl} />
+                        {status.url && (
+                            <LinkBox href={status.url} target="_blank">
+                                <Icon icon="launch" /> {pettyUrl(status.url)}
+                            </LinkBox>
+                        )}
+                        <User username={status.username} url={status.userUrl} />
                         <Box>
-                            <Icon icon="commit" /> {status.branch}
+                            <Icon icon="schedule" /> <TimePassed since={status.time} />
                         </Box>
-                    )}
-                    {status.tag && (
-                        <Box>
-                            <Icon icon="bookmark_border" /> {status.tag}
-                        </Box>
-                    )}
-                    <Merge title={status.mergeTitle} url={status.mergeUrl} />
-                    {status.url && (
-                        <LinkBox href={status.url} target="_blank">
-                            <Icon icon="launch" /> {pettyUrl(status.url)}
-                        </LinkBox>
-                    )}
-                    <User username={status.username} url={status.userUrl} />
-                    <Box>
-                        <Icon icon="schedule" /> <TimePassed since={status.time} />
-                    </Box>
-                </Boxes>
-            </Details>
-            {status.userImage && (
-                <UserImage>
-                    <img src={status.userImage} alt="User" />
-                </UserImage>
-            )}
-        </Body>
-        {status.processes && status.processes.map((process) => <Process key={process.id} process={process} />)}
-    </Container>
-);
+                    </Boxes>
+                </Details>
+                {status.userImage && showUserAvatar && (
+                    <UserImage>
+                        <img src={status.userImage} alt="User" />
+                    </UserImage>
+                )}
+            </Body>
+            {status.processes && status.processes.map((process) => <Process key={process.id} process={process} />)}
+        </Container>
+    );
+};
 
 export default Statuses;

--- a/frontend/App/Statuses/Status/User/User.tsx
+++ b/frontend/App/Statuses/Status/User/User.tsx
@@ -5,28 +5,28 @@ import { Box, LinkBox } from '/frontend/App/Statuses/Status/Status.style';
 import Icon from '/frontend/components/Icon';
 
 type Props = {
-    title?: string;
+    username?: string;
     url?: string;
 };
 
-const Merge = ({ title, url }: Props): ReactElement | null => {
-    if (!title && !url) {
+const User = ({ username, url }: Props): ReactElement | null => {
+    if (!username && !url) {
         return null;
     }
 
     if (url) {
         return (
             <LinkBox href={url} target="_blank">
-                <Icon icon="merge_type" /> {title || 'request'}
+                <Icon icon="person" /> {username || 'User'}
             </LinkBox>
         );
     }
 
     return (
         <Box>
-            <Icon icon="merge_type" /> {title}
+            <Icon icon="merge_type" /> {username}
         </Box>
     );
 };
 
-export default Merge;
+export default User;

--- a/frontend/App/Statuses/Status/User/index.tsx
+++ b/frontend/App/Statuses/Status/User/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './User';

--- a/frontend/store/cache/reducer.ts
+++ b/frontend/store/cache/reducer.ts
@@ -2,9 +2,9 @@ import { ActionTypes, StateType } from './types';
 
 const defaultState: StateType = {
     version: null,
-    lastVersionCheck: new Date().getTime(),
+    lastVersionCheck: 0,
     contributors: [],
-    lastContributorCheck: new Date().getTime(),
+    lastContributorCheck: 0,
 };
 
 const reducer = (state = defaultState, action: ActionTypes): StateType => {

--- a/frontend/store/settings/actions.ts
+++ b/frontend/store/settings/actions.ts
@@ -3,10 +3,15 @@ import {
     SetSizeModifierAction,
     ToggleSettingsPanelAction,
     ToggleShowCompletedAction,
+    ToggleShowUserAvatarsAction,
 } from './types';
 
 export const toggleShowCompleted = (): ToggleShowCompletedAction => ({
     type: 'settings-show-completed-toggle',
+});
+
+export const toggleShowUserAvatars = (): ToggleShowUserAvatarsAction => ({
+    type: 'settings-show-user-avatars-toggle',
 });
 
 export const toggleSettingsPanel = (): ToggleSettingsPanelAction => ({

--- a/frontend/store/settings/reducer.ts
+++ b/frontend/store/settings/reducer.ts
@@ -4,6 +4,7 @@ const defaultState: StateType = {
     open: false,
     showCompleted: false,
     sizeModifier: 1,
+    showUserAvatars: true,
 };
 
 const reducer = (state = defaultState, action: ActionTypes): StateType => {
@@ -27,6 +28,11 @@ const reducer = (state = defaultState, action: ActionTypes): StateType => {
             return {
                 ...state,
                 sizeModifier: action.sizeModifier,
+            };
+        case 'settings-show-user-avatars-toggle':
+            return {
+                ...state,
+                showUserAvatars: !state.showUserAvatars,
             };
         default:
             return state;

--- a/frontend/store/settings/selectors.ts
+++ b/frontend/store/settings/selectors.ts
@@ -4,5 +4,7 @@ export const isSettingsPanelOpen = (state: RootState): boolean => state.setting.
 
 export const isShowingCompleted = (state: RootState): boolean => state.setting.showCompleted;
 
+export const isShowingUserAvatars = (state: RootState): boolean => state.setting.showUserAvatars;
+
 export const getSizeModifier = (state: RootState): number =>
     state.setting.sizeModifier ? state.setting.sizeModifier : 1;

--- a/frontend/store/settings/types.ts
+++ b/frontend/store/settings/types.ts
@@ -2,6 +2,7 @@ export type StateType = {
     open: boolean;
     showCompleted: boolean;
     sizeModifier: number;
+    showUserAvatars: boolean;
 };
 
 export type SetSizeModifierAction = {
@@ -21,8 +22,13 @@ export type CloseSettingsPanelAction = {
     type: 'settings-panel-close';
 };
 
+export type ToggleShowUserAvatarsAction = {
+    type: 'settings-show-user-avatars-toggle';
+};
+
 export type ActionTypes =
     | ToggleSettingsPanelAction
     | CloseSettingsPanelAction
     | ToggleShowCompletedAction
-    | SetSizeModifierAction;
+    | SetSizeModifierAction
+    | ToggleShowUserAvatarsAction;

--- a/types/github.ts
+++ b/types/github.ts
@@ -34,6 +34,7 @@ export type GitHubRelease = {
 type GitHubSender = {
     login: string;
     avatar_url: string;
+    html_url: string;
 };
 
 type GitHubOrganization = {
@@ -92,7 +93,7 @@ export type GitHubPullRequest = {
     };
     repository: GitHubRepository;
     organization: GitHubOrganization;
-    sender: GitHubUser;
+    sender: GitHubSender;
 };
 
 export type GitHubContributor = {

--- a/types/status.ts
+++ b/types/status.ts
@@ -42,13 +42,15 @@ export type Status = {
     processes: Process[];
     time: string;
     source: 'github' | 'gitlab' | 'readthedocs';
-    source_url?: string;
+    sourceUrl?: string;
     url?: string;
     branch?: string;
     tag?: string;
     issue?: number;
     projectImage?: string;
+    username?: string;
     userImage?: string;
+    userUrl?: string;
     mergeTitle?: string;
     mergeUrl?: string;
 };


### PR DESCRIPTION
# What

Add user with profile URL to statuses.

- For GitLab the user name is set when provided with a link to the profile. Falls back to the username
- For GitHub is the login name is set with a link to the profile

## Why

As requested in #181, user names are now included in the statuses.

## Screenshot

![image](https://user-images.githubusercontent.com/6495166/167217864-0dd82bcc-337f-4904-8603-1f90e71867ef.png)

