### PR TITLE
Fix the toolbar background corners to ensure no gaps appear

### DIFF
--- a/frontend/App/Toolbar/Toolbar.style.tsx
+++ b/frontend/App/Toolbar/Toolbar.style.tsx
@@ -86,19 +86,21 @@ export const Brand = styled.div`
 		bottom: 0;
 		position: absolute;
 		content: '';
-		box-shadow: 0 0 0 50px #fff;
-		clip: rect(0, ${radius}rem, ${radius}rem, 0);
 		display: block;
 	}
 
 	&::after {
 		right: -${radius}rem;
-		border-bottom-left-radius: 100%;
+		background-image: radial-gradient(
+			circle at ${radius}rem 0,
+			rgba(204, 0, 0, 0) ${radius}rem,
+			white ${radius + 0.1}rem
+		);
 	}
 
 	&::before {
 		left: -${radius}rem;
-		border-bottom-right-radius: 100%;
+		background-image: radial-gradient(circle at 0 0, rgba(204, 0, 0, 0) ${radius}rem, white ${radius + 0.1}rem);
 	}
 
 	svg {


### PR DESCRIPTION
# What

Before | After
--- | ---
![image](https://user-images.githubusercontent.com/6495166/206500928-f1e3f525-2e91-47dc-b86d-cc47e08a2e25.png) | ![image](https://user-images.githubusercontent.com/6495166/206501108-6098718f-a531-4a69-abb1-0d1637d4aa0d.png)

## Why

With the previous solution, ugly gaps could appear in the corners of the logo background. With the new fix this is no longer happening.
