### PR TITLE
Prioritize running job over success or failed status

### DIFF
--- a/frontend/store/status/selectors.ts
+++ b/frontend/store/status/selectors.ts
@@ -5,12 +5,12 @@ import Status, { State } from '/types/status';
 export const getStatuses = (state: RootState): Status[] => state.status.statuses;
 
 export const getGlobalState = (state: RootState): State => {
-	if (state.status.statuses.find((status) => status.state === 'error')) {
-		return 'error';
-	}
-
 	if (state.status.statuses.find((status) => status.state === 'warning')) {
 		return 'warning';
+	}
+
+	if (state.status.statuses.find((status) => status.state === 'error')) {
+		return 'error';
 	}
 
 	return 'success';


### PR DESCRIPTION
# What

This change prioritizes the global state of running jobs over the end states (failure /  success). If a pipeline is running, the favicon and bottom traffic light will be yellow, once the pipeline is completed the favicon + traffic light will be green or red again. 

## Why

I recently have been using CIMonitor in a (pinned) tab quite a lot as a simple indicator if the pipeline was still running or already done. Whenever I would have failed pipelines on my dashboard (this can happen quite some times when running e.g. Renovate or Dependabot), the indicator never switches to yellow so I still have to check the CIMonitor page manually to know if the pipeline I just triggered is already done.

With this change, the favicon will update itself to yellow whenever a pipeline starts, then back to red or green again when the pipeline is completed.

In other words, this makes the favicon / traffic light more usable in different scenario's!