### PR TITLE
Show Gravatar user images in high resolution

### DIFF
--- a/frontend/App/Statuses/Status/Status.tsx
+++ b/frontend/App/Statuses/Status/Status.tsx
@@ -18,6 +18,16 @@ type Props = {
 	status: Status;
 };
 
+const highResAvatar = (url: string): string => {
+	if (!new URL(url).hostname.endsWith('gravatar.com')) {
+		return url;
+	}
+
+	const parsed = new URL(url);
+	parsed.searchParams.set('s', '400');
+	return parsed.toString();
+};
+
 const pettyUrl = (url: string) =>
 	String(url)
 		// strip http(s)://
@@ -41,7 +51,9 @@ const Statuses = ({ status }: Props): ReactElement => {
 						onError={() => setProjectAvatarFailed(true)}
 					/>
 				)}
-				{!!status.userImage && showAvatars && <UserImage src={status.userImage} alt={status.username} />}
+				{!!status.userImage && showAvatars && (
+					<UserImage src={highResAvatar(status.userImage)} alt={status.username} />
+				)}
 				<Details>
 					<Project>{status.project}</Project>
 					<Boxes>

--- a/frontend/App/Statuses/Status/Status.tsx
+++ b/frontend/App/Statuses/Status/Status.tsx
@@ -19,13 +19,15 @@ type Props = {
 };
 
 const highResAvatar = (url: string): string => {
-	if (!new URL(url).hostname.endsWith('gravatar.com')) {
-		return url;
+	const parsedUrl = new URL(url);
+	
+	// Improve gravatar image resolution
+	if (parsedUrl.hostname.endsWith('gravatar.com')) {
+		parsedUrl.searchParams.set('s', '512')
+		return parsedUrl;
 	}
 
-	const parsed = new URL(url);
-	parsed.searchParams.set('s', '400');
-	return parsed.toString();
+	return url;
 };
 
 const pettyUrl = (url: string) =>

--- a/frontend/App/Statuses/Status/Status.tsx
+++ b/frontend/App/Statuses/Status/Status.tsx
@@ -20,11 +20,11 @@ type Props = {
 
 const highResAvatar = (url: string): string => {
 	const parsedUrl = new URL(url);
-	
+
 	// Improve gravatar image resolution
 	if (parsedUrl.hostname.endsWith('gravatar.com')) {
-		parsedUrl.searchParams.set('s', '512')
-		return parsedUrl;
+		parsedUrl.searchParams.set('s', '512');
+		return parsedUrl.toString();
 	}
 
 	return url;


### PR DESCRIPTION
# What

Avatars currently show a mix of highres / sharp images coming from sources like GitLab / GitHub directly, or low res / blurry images coming from Gravatar. This detects Gravatar URLs and updates the requested size so Gravatar images are also sharp and nice to look at.

## Why

I like nice things to look at.
